### PR TITLE
allow to set ALLOWED_SYSCALLS environment variables

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -7,6 +7,7 @@ max_requests: 50
 worker_timeout: 5
 python_path: /usr/local/bin/python3
 enable_network: True # please make sure there is no network risk in your environment
+allowed_syscalls: # please leave it empty if you have no idea how seccomp works
 proxy:
   socks5: ''
   http: ''

--- a/internal/core/runner/nodejs/nodejs.go
+++ b/internal/core/runner/nodejs/nodejs.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner"
@@ -40,6 +41,8 @@ func (p *NodeJsRunner) Run(
 	preload string,
 	options *types.RunnerOptions,
 ) (chan []byte, chan []byte, chan bool, error) {
+	configuration := static.GetDifySandboxGlobalConfigurations()
+
 	// capture the output
 	output_handler := runner.NewOutputCaptureRunner()
 	output_handler.SetTimeout(timeout)
@@ -66,8 +69,8 @@ func (p *NodeJsRunner) Run(
 		)
 		cmd.Env = []string{}
 
-		if os.Getenv("ALLOWED_SYSCALLS") != "" {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("ALLOWED_SYSCALLS=%s", os.Getenv("ALLOWED_SYSCALLS")))
+		if len(configuration.AllowedSyscalls) > 0 {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("ALLOWED_SYSCALLS=%s", strings.Trim(strings.Join(strings.Fields(fmt.Sprint(configuration.AllowedSyscalls)), ","), "[]")))
 		}
 
 		// capture the output

--- a/internal/core/runner/nodejs/nodejs.go
+++ b/internal/core/runner/nodejs/nodejs.go
@@ -66,6 +66,10 @@ func (p *NodeJsRunner) Run(
 		)
 		cmd.Env = []string{}
 
+		if os.Getenv("ALLOWED_SYSCALLS") != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("ALLOWED_SYSCALLS=%s", os.Getenv("ALLOWED_SYSCALLS")))
+		}
+
 		// capture the output
 		err = output_handler.CaptureOutput(cmd)
 		if err != nil {

--- a/internal/core/runner/python/python.go
+++ b/internal/core/runner/python/python.go
@@ -77,8 +77,8 @@ func (p *PythonRunner) Run(
 				cmd.Env = append(cmd.Env, fmt.Sprintf("HTTP_PROXY=%s", configuration.Proxy.Http))
 			}
 		}
-		if os.Getenv("ALLOWED_SYSCALLS") != "" {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("ALLOWED_SYSCALLS=%s", os.Getenv("ALLOWED_SYSCALLS")))
+		if len(configuration.AllowedSyscalls) > 0 {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("ALLOWED_SYSCALLS=%s", strings.Trim(strings.Join(strings.Fields(fmt.Sprint(configuration.AllowedSyscalls)), ","), "[]")))
 		}
 
 		err = output_handler.CaptureOutput(cmd)

--- a/internal/core/runner/python/python.go
+++ b/internal/core/runner/python/python.go
@@ -77,6 +77,9 @@ func (p *PythonRunner) Run(
 				cmd.Env = append(cmd.Env, fmt.Sprintf("HTTP_PROXY=%s", configuration.Proxy.Http))
 			}
 		}
+		if os.Getenv("ALLOWED_SYSCALLS") != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("ALLOWED_SYSCALLS=%s", os.Getenv("ALLOWED_SYSCALLS")))
+		}
 
 		err = output_handler.CaptureOutput(cmd)
 		if err != nil {

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -92,6 +92,19 @@ func InitConfig(path string) error {
 		difySandboxGlobalConfigurations.EnableNetwork, _ = strconv.ParseBool(enable_network)
 	}
 
+	allowed_syscalls := os.Getenv("ALLOWED_SYSCALLS")
+	if allowed_syscalls != "" {
+		strs := strings.Split(allowed_syscalls, ",")
+		ary := make([]int, len(strs))
+		for i := range ary {
+			ary[i], err = strconv.Atoi(strs[i])
+			if err != nil {
+				return err
+			}
+		}
+		difySandboxGlobalConfigurations.AllowedSyscalls = ary
+	}
+
 	if difySandboxGlobalConfigurations.EnableNetwork {
 		log.Info("network has been enabled")
 		socks5_proxy := os.Getenv("SOCKS5_PROXY")

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -6,14 +6,15 @@ type DifySandboxGlobalConfigurations struct {
 		Debug bool   `yaml:"debug"`
 		Key   string `yaml:"key"`
 	} `yaml:"app"`
-	MaxWorkers     int      `yaml:"max_workers"`
-	MaxRequests    int      `yaml:"max_requests"`
-	WorkerTimeout  int      `yaml:"worker_timeout"`
-	PythonPath     string   `yaml:"python_path"`
-	PythonLibPaths []string `yaml:"python_lib_path"`
-	NodejsPath     string   `yaml:"nodejs_path"`
-	EnableNetwork  bool     `yaml:"enable_network"`
-	Proxy          struct {
+	MaxWorkers      int      `yaml:"max_workers"`
+	MaxRequests     int      `yaml:"max_requests"`
+	WorkerTimeout   int      `yaml:"worker_timeout"`
+	PythonPath      string   `yaml:"python_path"`
+	PythonLibPaths  []string `yaml:"python_lib_path"`
+	NodejsPath      string   `yaml:"nodejs_path"`
+	EnableNetwork   bool     `yaml:"enable_network"`
+	AllowedSyscalls []int    `yaml:"allowed_syscalls"`
+	Proxy           struct {
 		Socks5 string `yaml:"socks5"`
 		Https  string `yaml:"https"`
 		Http   string `yaml:"http"`

--- a/tests/integration_tests/conf/config.yaml
+++ b/tests/integration_tests/conf/config.yaml
@@ -7,6 +7,7 @@ max_requests: 50
 worker_timeout: 5
 python_path: /usr/bin/python3
 enable_network: True # please make sure there is no network risk in your environment
+allowed_syscalls: # please leave it empty if you have no idea how seccomp works
 proxy:
   socks5: ''
   http: ''


### PR DESCRIPTION
Usecase: I want to allow certain system calls without re-building the sandbox binary to use some additional packages.

The ALLOWED_SYSCALLS is read here in the child process:

https://github.com/langgenius/dify-sandbox/blob/d848aa91a1669b4a1f5052f53993445f4c8163b1/internal/core/lib/python/add_seccomp.go#L31-L40

Let me know if there is any reason to deny to set ALLOWED_SYSCALLS environment variables dynamically 🙏 