### PR TITLE
fix: symbolic links in python_lib_path directory are ignored

### DIFF
--- a/internal/core/runner/python/env.sh
+++ b/internal/core/runner/python/env.sh
@@ -37,7 +37,7 @@ elif [ -d "$src" ]; then
     mkdir -p "$dest/$src"
 
     # Find all files in the source directory
-    find "$src" -type f | while read -r file; do
+    find "$src" -type f,l | while read -r file; do
         # Get the relative path of the file
         rel_path="${file#$src/}"
         # Get the directory of the relative path


### PR DESCRIPTION
closes #48 

This PR adds [`-type l` option](https://man7.org/linux/man-pages/man1/find.1.html) to the find command used for listing all the targets in a source directory.

I confirmed this change fixes the original issue sucessfully without disruption.

Usecase: I want to add all the files in /usr/lib because many libraries require different shared libraries in the directory, and it is troublesome to add those files one by one.