### PR TITLE
fix third-party dependency usage errors, such as requests

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -12,3 +12,5 @@ proxy:
   socks5: ''
   http: ''
   https: ''
+python_lib_path:
+  - "/usr/lib/x86_64-linux-gnu"


### PR DESCRIPTION
close #54 
Solve the problem of third -party dependencies, especially Reqeusts，because it is used as a built -in library of Sanbox, it should be used directly.