### PR TITLE
bugfix: update the process proceeds to the next step when InstallDependencies failed (#67)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,18 +63,25 @@ func initDependencies() {
 	go func() {
 		ticker := time.NewTicker(30 * time.Minute)
 		for range ticker.C {
-			log.Info("updating python dependencies...")
-			err := python.InstallDependencies(dependencies.PythonRequirements)
-			if err != nil {
-				log.Error("failed to update python dependencies: %v", err)
+			if err:=updatePythonDependencies(dependencies);err!=nil{
+				log.Error("Failed to update Python dependencies: %v", err)
 			}
-			err = python.PreparePythonDependenciesEnv()
-			if err != nil {
-				log.Error("failed to update python dependencies sandbox: %v", err)
-			}
-			log.Info("python dependencies updated")
 		}
 	}()
+}
+
+func updatePythonDependencies(dependencies static.RunnerDependencies) error {
+	log.Info("Updating Python dependencies...")
+	if err := python.InstallDependencies(dependencies.PythonRequirements); err != nil {
+		log.Error("Failed to install Python dependencies: %v", err)
+		return err
+	}
+	if err := python.PreparePythonDependenciesEnv(); err != nil {
+		log.Error("Failed to prepare Python dependencies environment: %v", err)
+		return err
+	}
+	log.Info("Python dependencies updated successfully.")
+	return nil
 }
 
 func Run() {


### PR DESCRIPTION
update the process proceeds to the next step when InstallDependencies failed during the scheduled update of Python dependencies.

close #67 