### PR TITLE
refactor: optimize the Dockerfile to reduce the image size

### DIFF
--- a/docker/amd64/dockerfile
+++ b/docker/amd64/dockerfile
@@ -1,10 +1,21 @@
 FROM python:3.10-slim-bookworm
 
-RUN apt-get clean \
-    && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
+# if you located in China, you can use aliyun mirror to speed up
+# && echo "deb http://mirrors.aliyun.com/debian testing main" > /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y pkg-config libseccomp-dev wget curl xz-utils \
-    && apt-get install -y --no-install-recommends zlib1g=1:1.3.dfsg+really1.3.1-1 expat=2.6.3-1 perl=5.38.2-5 libsqlite3-0=3.46.0-1
+    && apt-get install -y --no-install-recommends \
+       pkg-config \
+       libseccomp-dev \
+       wget \
+       curl \
+       xz-utils \
+       zlib1g=1:1.3.dfsg+really1.3.1-1 \
+       expat=2.6.3-1 \
+       perl=5.38.2-5 \
+       libsqlite3-0=3.46.0-1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # copy main binary to /main
 COPY main /main
@@ -16,10 +27,8 @@ COPY conf/config.yaml /conf/config.yaml
 # copy python dependencies
 COPY dependencies/python-requirements.txt /dependencies/python-requirements.txt
 
-RUN rm -rf /var/lib/apt/lists/* \
-    && chmod +x /main \
-    && chmod +x /env \
-    && pip3 install jinja2 requests httpx PySocks httpx[socks] \
+RUN chmod +x /main /env \
+    && pip3 install --no-cache-dir jinja2 requests httpx PySocks httpx[socks] \
     && wget -O /opt/node-v20.11.1-linux-x64.tar.xz https://npmmirror.com/mirrors/node/v20.11.1/node-v20.11.1-linux-x64.tar.xz \
     && tar -xvf /opt/node-v20.11.1-linux-x64.tar.xz -C /opt \
     && ln -s /opt/node-v20.11.1-linux-x64/bin/node /usr/local/bin/node \

--- a/docker/arm64/dockerfile
+++ b/docker/arm64/dockerfile
@@ -1,10 +1,21 @@
 FROM python:3.10-slim-bookworm
 
-RUN apt-get clean \
-    && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
+# if you located in China, you can use aliyun mirror to speed up
+# && echo "deb http://mirrors.aliyun.com/debian testing main" > /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y pkg-config libseccomp-dev wget curl xz-utils \
-    && apt-get install -y --no-install-recommends zlib1g=1:1.3.dfsg+really1.3.1-1 expat=2.6.3-1 perl=5.38.2-5 libsqlite3-0=3.46.0-1
+    && apt-get install -y --no-install-recommends
+       pkg-config \
+       libseccomp-dev \
+       wget \
+       curl \
+       xz-utils \
+       zlib1g=1:1.3.dfsg+really1.3.1-1 \
+       expat=2.6.3-1 \
+       perl=5.38.2-5 \
+       libsqlite3-0=3.46.0-1 \
+    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 # copy main binary to /main
 COPY main /main
@@ -16,10 +27,8 @@ COPY conf/config.yaml /conf/config.yaml
 # copy python dependencies
 COPY dependencies/python-requirements.txt /dependencies/python-requirements.txt
 
-RUN rm -rf /var/lib/apt/lists/* \
-    && chmod +x /main \
-    && chmod +x /env \
-    && pip3 install jinja2 requests httpx PySocks httpx[socks] \
+RUN chmod +x /main /env \
+    && pip3 install --no-cache-dir jinja2 requests httpx PySocks httpx[socks] \
     && wget -O /opt/node-v20.11.1-linux-arm64.tar.xz https://npmmirror.com/mirrors/node/v20.11.1/node-v20.11.1-linux-arm64.tar.xz \
     && tar -xvf /opt/node-v20.11.1-linux-arm64.tar.xz -C /opt \
     && ln -s /opt/node-v20.11.1-linux-arm64/bin/node /usr/local/bin/node \


### PR DESCRIPTION
1.Add the --no-install-recommends option to the apt-get install command to reduce unnecessary installations.
2.Run the apt-get clean command after apt-get install to reduce cache.
3.Run rm -rf /var/lib/apt/lists/* after apt-get install to ensure cache is removed within the same layer.
4.Use the --no-cache-dir option when installing Python packages to reduce the size.