### PR TITLE
fix: Version '2.6.3-1' for 'expat' was not found

### DIFF
--- a/docker/amd64/dockerfile
+++ b/docker/amd64/dockerfile
@@ -10,9 +10,9 @@ RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list
        wget \
        curl \
        xz-utils \
-       zlib1g=1:1.3.dfsg+really1.3.1-1 \
-       expat=2.6.3-1 \
-       perl=5.40.0-6 \
+       zlib1g=1:1.3.dfsg+really1.3.1-1+b1 \
+       expat=2.6.4-1 \
+       perl=5.40.0-7 \
        libsqlite3-0=3.46.1-1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
use amd64/dockerfile and run "docker build -t langgenius/dify-sandbox:0.2.10 ."
fail to build image:
```
6.607 Building dependency tree...
6.796 Reading state information...
6.802 Package zlib1g is not available, but is referred to by another package.
6.802 This may mean that the package is missing, has been obsoleted, or
6.802 is only available from another source
6.802
6.802 Package perl is not available, but is referred to by another package.
6.802 This may mean that the package is missing, has been obsoleted, or
6.802 is only available from another source
6.802 However the following packages replace it:
6.802   perl-base libperl5.36 libperl5.38t64 libperl5.40
6.802
6.802 Package libsqlite3-0 is not available, but is referred to by another package.
6.802 This may mean that the package is missing, has been obsoleted, or
6.802 is only available from another source
6.802
6.802 Package expat is not available, but is referred to by another package.
6.802 This may mean that the package is missing, has been obsoleted, or
6.802 is only available from another source
6.802
6.808 E: Version '1:1.3.dfsg+really1.3.1-1' for 'zlib1g' was not found
6.808 E: Version '2.6.3-1' for 'expat' was not found
6.808 E: Version '5.38.2-5' for 'perl' was not found
6.808 E: Version '3.46.0-1' for 'libsqlite3-0' was not found
------
Dockerfile:4
--------------------
   3 |     # if you located in China, you can use aliyun mirror to speed up
   4 | >>> RUN echo "deb http://mirrors.aliyun.com/debian testing main" > /etc/apt/sources.list \
   5 | >>> # RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list \
   6 | >>>     && apt-get update \
   7 | >>>     && apt-get install -y --no-install-recommends \
   8 | >>>        pkg-config \
   9 | >>>        libseccomp-dev \
  10 | >>>        wget \
  11 | >>>        curl \
  12 | >>>        xz-utils \
  13 | >>>        zlib1g=1:1.3.dfsg+really1.3.1-1 \
  14 | >>>        expat=2.6.3-1 \
  15 | >>>        perl=5.38.2-5 \
  16 | >>>        libsqlite3-0=3.46.0-1 \
  17 | >>>     && apt-get clean \
  18 | >>>     && rm -rf /var/lib/apt/lists/*
  19 |
--------------------
ERROR: failed to solve: process "/bin/sh -c echo \"deb http://mirrors.aliyun.com/debian testing main\" > /etc/apt/sources.list     && apt-get update     && apt-get install -y --no-install-recommends        pkg-config        libseccomp-dev        wget        curl        xz-utils        zlib1g=1:1.3.dfsg+really1.3.1-1        expat=2.6.3-1        perl=5.38.2-5        libsqlite3-0=3.46.0-1     && apt-get clean     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```