### PR TITLE
feat: Allow Nodejs async fetch

### DIFF
--- a/internal/core/lib/nodejs/add_seccomp.go
+++ b/internal/core/lib/nodejs/add_seccomp.go
@@ -26,6 +26,7 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 
 	allowed_syscalls := []int{}
 	allowed_not_kill_syscalls := []int{}
+	allowed_syscall_values := map[int]uint64{}
 
 	allowed_syscall := os.Getenv("ALLOWED_SYSCALLS")
 	if allowed_syscall != "" {
@@ -43,10 +44,11 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 
 		if enable_network {
 			allowed_syscalls = append(allowed_syscalls, nodejs_syscall.ALLOW_NETWORK_SYSCALLS...)
+			allowed_syscall_values = nodejs_syscall.ALLOW_NETWORK_SYSCALL_VALUES
 		}
 	}
 
-	err = lib.Seccomp(allowed_syscalls, allowed_not_kill_syscalls)
+	err = lib.Seccomp(allowed_syscalls, allowed_not_kill_syscalls, allowed_syscall_values)
 	if err != nil {
 		return err
 	}

--- a/internal/core/lib/python/add_seccomp.go
+++ b/internal/core/lib/python/add_seccomp.go
@@ -45,7 +45,7 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 		}
 	}
 
-	err = lib.Seccomp(allowed_syscalls, allowed_not_kill_syscalls)
+	err = lib.Seccomp(allowed_syscalls, allowed_not_kill_syscalls, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/core/lib/seccomp.go
+++ b/internal/core/lib/seccomp.go
@@ -10,7 +10,7 @@ import (
 	sg "github.com/seccomp/libseccomp-golang"
 )
 
-func Seccomp(allowed_syscalls []int, allowed_not_kill_syscalls []int) error {
+func Seccomp(allowed_syscalls []int, allowed_not_kill_syscalls []int, allowed_syscall_values map[int]uint64) error {
 	ctx, err := sg.NewFilter(sg.ActKillProcess)
 	if err != nil {
 		return err
@@ -23,12 +23,25 @@ func Seccomp(allowed_syscalls []int, allowed_not_kill_syscalls []int) error {
 	defer reader.Close()
 	defer writer.Close()
 
-	for _, syscall := range allowed_syscalls {
-		ctx.AddRule(sg.ScmpSyscall(syscall), sg.ActAllow)
+	for _, sc := range allowed_syscalls {
+		val, ok := allowed_syscall_values[sc]
+		if ok {
+			ctx.AddRuleConditional(sg.ScmpSyscall(sc), sg.ActAllow, []sg.ScmpCondition{
+				{Argument: 0, Op: sg.CompareEqual, Operand1: val},
+			})
+		} else {
+			ctx.AddRule(sg.ScmpSyscall(sc), sg.ActAllow)
+		}
 	}
 
-	for _, syscall := range allowed_not_kill_syscalls {
-		ctx.AddRule(sg.ScmpSyscall(syscall), sg.ActErrno)
+	for _, sc := range allowed_not_kill_syscalls {
+		switch sc {
+		case SYS_CLONE3:
+			// use ENOSYS for CLONE3, see: https://github.com/moby/moby/issues/42680
+			ctx.AddRule(sg.ScmpSyscall(sc), sg.ActErrno.SetReturnCode(int16(syscall.ENOSYS)))
+		default:
+			ctx.AddRule(sg.ScmpSyscall(sc), sg.ActErrno)
+		}
 	}
 
 	file := os.NewFile(uintptr(writer.Fd()), "pipe")

--- a/internal/core/lib/seccomp_syscall_amd64.go
+++ b/internal/core/lib/seccomp_syscall_amd64.go
@@ -4,4 +4,5 @@ package lib
 
 const (
 	SYS_SECCOMP = 317
+	SYS_CLONE3  = 435
 )

--- a/internal/core/lib/seccomp_syscall_arm64.go
+++ b/internal/core/lib/seccomp_syscall_arm64.go
@@ -6,4 +6,5 @@ import "syscall"
 
 const (
 	SYS_SECCOMP = syscall.SYS_SECCOMP
+	SYS_CLONE3  = 435
 )

--- a/internal/static/nodejs_syscall/syscalls_amd64.go
+++ b/internal/static/nodejs_syscall/syscalls_amd64.go
@@ -2,13 +2,24 @@
 
 package nodejs_syscall
 
-import "syscall"
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
 
 const (
 	//334
 	SYS_RSEQ = 334
 	// 435
 	SYS_CLONE3 = 435
+
+	SYS_SENDMMSG      = 307
+	SYS_GETRANDOM     = 318
+	SYS_PKEY_ALLOC    = 329
+	SYS_PKEY_MPROTECT = 330
+	SYS_PKEY_FREE     = 331
+	SYS_STATX         = 332
 )
 
 var ALLOW_SYSCALLS = []int{
@@ -30,7 +41,6 @@ var ALLOW_SYSCALLS = []int{
 	SYS_RSEQ,
 
 	syscall.SYS_SETUID, syscall.SYS_SETGID, syscall.SYS_GETTID,
-
 	syscall.SYS_CLOCK_GETTIME, syscall.SYS_GETTIMEOFDAY, syscall.SYS_NANOSLEEP,
 	syscall.SYS_TIME,
 
@@ -38,10 +48,17 @@ var ALLOW_SYSCALLS = []int{
 
 	syscall.SYS_READLINK,
 	syscall.SYS_DUP3,
+
+	syscall.SYS_PIPE2,
+	syscall.SYS_SET_TID_ADDRESS,
+	syscall.SYS_PREAD64, syscall.SYS_PWRITE64,
+
+	SYS_GETRANDOM,
+	syscall.SYS_EPOLL_CREATE1, syscall.SYS_EVENTFD2,
 }
 
 var ALLOW_ERROR_SYSCALLS = []int{
-	syscall.SYS_CLONE, SYS_CLONE3,
+	SYS_CLONE3, /* return ENOSYS for glibc */
 }
 
 var ALLOW_NETWORK_SYSCALLS = []int{
@@ -49,4 +66,12 @@ var ALLOW_NETWORK_SYSCALLS = []int{
 	syscall.SYS_GETSOCKNAME, syscall.SYS_RECVMSG, syscall.SYS_GETPEERNAME, syscall.SYS_SETSOCKOPT, syscall.SYS_PPOLL, syscall.SYS_UNAME,
 	syscall.SYS_SENDMSG, syscall.SYS_GETSOCKOPT,
 	syscall.SYS_FCNTL, syscall.SYS_FSTATFS,
+	SYS_SENDMMSG, syscall.SYS_POLL,
+	SYS_PKEY_ALLOC, SYS_PKEY_MPROTECT, SYS_PKEY_FREE, SYS_STATX,
+	syscall.SYS_CLONE,
+}
+
+var ALLOW_NETWORK_SYSCALL_VALUES = map[int]uint64{
+	// allow clone for nodejs networking
+	syscall.SYS_CLONE: unix.CLONE_VM | unix.CLONE_FS | unix.CLONE_FILES | unix.CLONE_SIGHAND | unix.CLONE_THREAD | unix.CLONE_SYSVSEM | unix.CLONE_SETTLS | unix.CLONE_PARENT_SETTID | unix.CLONE_CHILD_CLEARTID,
 }

--- a/internal/static/nodejs_syscall/syscalls_arm64.go
+++ b/internal/static/nodejs_syscall/syscalls_arm64.go
@@ -42,3 +42,5 @@ var ALLOW_NETWORK_SYSCALLS = []int{
 	syscall.SYS_FSTATAT, syscall.SYS_LSEEK,
 	syscall.SYS_FSTATFS,
 }
+
+var ALLOW_NETWORK_SYSCALL_VALUES = map[int]uint64{}


### PR DESCRIPTION
In this PR, we add new syscall rules to allow use of `fetch` async function in Nodejs runtime.

Also, Code template in dify api should be replaced by:

```
        runner_script = dedent(
            f"""
            // declare main function
            {cls._code_placeholder}
            
            // decode and prepare input object
            var inputs_obj = JSON.parse(Buffer.from('{cls._inputs_placeholder}', 'base64').toString('utf-8'))
            
            // execute main function
            async function wrap() {"{"}
            var output_obj = await main(inputs_obj)
            
            // convert output to json and print
            var output_json = JSON.stringify(output_obj)
            var result = `<<RESULT>>${{output_json}}<<RESULT>>`
            console.log(result)
            {"}"}
            wrap()
            """
        )
```

see: https://github.com/langgenius/dify/blob/7f095bdc42bc9482304c4e4f937d9b72b3aa9759/api/core/helper/code_executor/javascript/javascript_transformer.py#L9

Note that, arm64 arch support is not tested yet.