### PR TITLE
fix: bump dep versions

### DIFF
--- a/.github/workflows/build-universal.yml
+++ b/.github/workflows/build-universal.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/vulns
   release:
     types: [published]
 

--- a/.github/workflows/build-universal.yml
+++ b/.github/workflows/build-universal.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/vulns
   release:
     types: [published]
 

--- a/docker/amd64-test/dockerfile
+++ b/docker/amd64-test/dockerfile
@@ -46,7 +46,7 @@ COPY conf/config.yaml /conf/config.yaml
 COPY dependencies/python-requirements.txt /dependencies/python-requirements.txt
 
 # install python dependencies
-RUN pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.0.3 PySocks httpx[socks]
+RUN pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.1.6 PySocks httpx[socks]
 
 # install node
 RUN wget -O /opt/node-v20.11.1-linux-x64.tar.xz https://npmmirror.com/mirrors/node/v20.11.1/node-v20.11.1-linux-x64.tar.xz \

--- a/docker/amd64/dockerfile
+++ b/docker/amd64/dockerfile
@@ -35,8 +35,7 @@ RUN chmod +x /main /env /entrypoint.sh \
     && /env \
     && rm -f /env
 
-ENTRYPOINT [
-    "NODE_TAR_XZ=/opt/node-v20.11.1-linux-x64.tar.xz", 
-    "NODE_DIR=/opt/node-v20.11.1-linux-x64", 
-    "/entrypoint.sh"
-]
+ENV NODE_TAR_XZ=/opt/node-v20.11.1-linux-x64.tar.xz
+ENV NODE_DIR=/opt/node-v20.11.1-linux-x64
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/amd64/dockerfile
+++ b/docker/amd64/dockerfile
@@ -26,14 +26,17 @@ COPY env /env
 COPY conf/config.yaml /conf/config.yaml
 # copy python dependencies
 COPY dependencies/python-requirements.txt /dependencies/python-requirements.txt
+# copy entrypoint
+COPY docker/entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /main /env \
-    && pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.0.3 PySocks httpx[socks] \
+RUN chmod +x /main /env /entrypoint.sh \
+    && pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.1.6 PySocks httpx[socks] \
     && wget -O /opt/node-v20.11.1-linux-x64.tar.xz https://npmmirror.com/mirrors/node/v20.11.1/node-v20.11.1-linux-x64.tar.xz \
-    && tar -xvf /opt/node-v20.11.1-linux-x64.tar.xz -C /opt \
-    && ln -s /opt/node-v20.11.1-linux-x64/bin/node /usr/local/bin/node \
-    && rm -f /opt/node-v20.11.1-linux-x64.tar.xz \
     && /env \
     && rm -f /env
 
-ENTRYPOINT ["/main"]
+ENTRYPOINT [
+    "NODE_TAR_XZ=/opt/node-v20.11.1-linux-x64.tar.xz", 
+    "NODE_DIR=/opt/node-v20.11.1-linux-x64", 
+    "/entrypoint.sh"
+]

--- a/docker/arm64-test/dockerfile
+++ b/docker/arm64-test/dockerfile
@@ -46,7 +46,7 @@ COPY conf/config.yaml /conf/config.yaml
 COPY dependencies/python-requirements.txt /dependencies/python-requirements.txt
 
 # install python dependencies
-RUN pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.0.3 PySocks httpx[socks]
+RUN pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.1.6 PySocks httpx[socks]
 
 # install node
 RUN wget -O /opt/node-v20.11.1-linux-arm64.tar.xz https://npmmirror.com/mirrors/node/v20.11.1/node-v20.11.1-linux-arm64.tar.xz \

--- a/docker/arm64/dockerfile
+++ b/docker/arm64/dockerfile
@@ -26,14 +26,17 @@ COPY env /env
 COPY conf/config.yaml /conf/config.yaml
 # copy python dependencies
 COPY dependencies/python-requirements.txt /dependencies/python-requirements.txt
+# copy entrypoint
+COPY docker/entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /main /env \
-    && pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.0.3 PySocks httpx[socks] \
+RUN chmod +x /main /env /entrypoint.sh \
+    && pip3 install --no-cache-dir httpx==0.27.2 requests==2.32.3 jinja2==3.1.6 PySocks httpx[socks] \
     && wget -O /opt/node-v20.11.1-linux-arm64.tar.xz https://npmmirror.com/mirrors/node/v20.11.1/node-v20.11.1-linux-arm64.tar.xz \
-    && tar -xvf /opt/node-v20.11.1-linux-arm64.tar.xz -C /opt \
-    && ln -s /opt/node-v20.11.1-linux-arm64/bin/node /usr/local/bin/node \
-    && rm -f /opt/node-v20.11.1-linux-arm64.tar.xz \
     && /env \
     && rm -f /env
 
-ENTRYPOINT ["/main"]
+ENTRYPOINT [
+    "NODE_TAR_XZ=/opt/node-v20.11.1-linux-arm64.tar.xz", 
+    "NODE_DIR=/opt/node-v20.11.1-linux-arm64", 
+    "/entrypoint.sh"
+]

--- a/docker/arm64/dockerfile
+++ b/docker/arm64/dockerfile
@@ -35,8 +35,7 @@ RUN chmod +x /main /env /entrypoint.sh \
     && /env \
     && rm -f /env
 
-ENTRYPOINT [
-    "NODE_TAR_XZ=/opt/node-v20.11.1-linux-arm64.tar.xz", 
-    "NODE_DIR=/opt/node-v20.11.1-linux-arm64", 
-    "/entrypoint.sh"
-]
+ENV NODE_TAR_XZ=/opt/node-v20.11.1-linux-arm64.tar.xz
+ENV NODE_DIR=/opt/node-v20.11.1-linux-arm64
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# decompress nodejs
+tar -xvf $NODE_TAR_XZ -C /opt
+ln -s $NODE_DIR/bin/node /usr/local/bin/node
+rm -f $NODE_TAR_XZ
+
+# start main
+/main


### PR DESCRIPTION
- Introduced a new entrypoint script to handle Node.js decompression and setup.
- Updated Dockerfiles for amd64 and arm64 architectures to include the new entrypoint.
- Adjusted permissions and installation steps for Python dependencies.
- Updated jinja2 version in Python requirements.