### PR TITLE
feat: Add `NO_PROXY` support for Python runner

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -13,3 +13,4 @@ proxy:
   socks5: ''
   http: ''
   https: ''
+  no_proxy: ''

--- a/internal/core/runner/python/python.go
+++ b/internal/core/runner/python/python.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/langgenius/dify-sandbox/internal/core/runner"
 	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
 	"github.com/langgenius/dify-sandbox/internal/static"
@@ -67,6 +68,9 @@ func (p *PythonRunner) Run(
 		}
 		if configuration.Proxy.Http != "" {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("HTTP_PROXY=%s", configuration.Proxy.Http))
+		}
+		if configuration.Proxy.NoProxy != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("NO_PROXY=%s", configuration.Proxy.NoProxy))
 		}
 	}
 

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -5,9 +5,10 @@ import (
 	"strconv"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/langgenius/dify-sandbox/internal/types"
 	"github.com/langgenius/dify-sandbox/internal/utils/log"
-	"gopkg.in/yaml.v3"
 )
 
 var difySandboxGlobalConfigurations types.DifySandboxGlobalConfigurations
@@ -148,6 +149,11 @@ func InitConfig(path string) error {
 		http_proxy := os.Getenv("HTTP_PROXY")
 		if http_proxy != "" {
 			difySandboxGlobalConfigurations.Proxy.Http = http_proxy
+		}
+
+		no_proxy := os.Getenv("NO_PROXY")
+		if no_proxy != "" {
+			difySandboxGlobalConfigurations.Proxy.NoProxy = no_proxy
 		}
 
 		if difySandboxGlobalConfigurations.Proxy.Http != "" {

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -18,8 +18,9 @@ type DifySandboxGlobalConfigurations struct {
 	EnablePreload            bool     `yaml:"enable_preload"`
 	AllowedSyscalls          []int    `yaml:"allowed_syscalls"`
 	Proxy                    struct {
-		Socks5 string `yaml:"socks5"`
-		Https  string `yaml:"https"`
-		Http   string `yaml:"http"`
+		Socks5  string `yaml:"socks5"`
+		Https   string `yaml:"https"`
+		Http    string `yaml:"http"`
+		NoProxy string `yaml:"no_proxy"`
 	} `yaml:"proxy"`
 }


### PR DESCRIPTION
This pull request adds support for the `NO_PROXY` environment variable to the Python runner. This feature allows for more flexible network configurations  by enabling direct access to specified hosts, bypassing the configured proxy.
