### PR TITLE
feat: custom dependency on request

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -8,6 +8,7 @@ worker_timeout: 5
 python_path: /usr/local/bin/python3
 enable_network: True # please make sure there is no network risk in your environment
 enable_preload: False # please keep it as False for security purposes
+enable_custom_dependencies: False # allow installing custom dependencies from http requests, please make sure there is no risk
 allowed_syscalls: # please leave it empty if you have no idea how seccomp works
 proxy:
   socks5: ''

--- a/docker/versions.yaml
+++ b/docker/versions.yaml
@@ -6,7 +6,7 @@ versions:
   nodejs: "v20.11.1"
   
   # Python packages (unified configuration)
-  python_packages: "httpx==0.27.2 requests==2.32.3 jinja2==3.1.6 PySocks httpx[socks]"
+  python_packages: "httpx==0.27.2 requests==2.32.3 jinja2==3.1.6 PySocks httpx[socks] uv==0.9.4"
   
   # System packages
   system_packages:

--- a/internal/controller/run.go
+++ b/internal/controller/run.go
@@ -9,19 +9,22 @@ import (
 
 func RunSandboxController(c *gin.Context) {
 	BindRequest(c, func(req struct {
-		Language      string `json:"language" form:"language" binding:"required"`
-		Code          string `json:"code" form:"code" binding:"required"`
-		Preload       string `json:"preload" form:"preload"`
-		EnableNetwork bool   `json:"enable_network" form:"enable_network"`
+		Language      string                    `json:"language" form:"language" binding:"required"`
+		Code          string                    `json:"code" form:"code" binding:"required"`
+		Preload       string                    `json:"preload" form:"preload"`
+		EnableNetwork bool                      `json:"enable_network" form:"enable_network"`
+		Dependencies  []runner_types.Dependency `json:"dependencies" form:"dependencies"`
 	}) {
 		switch req.Language {
 		case "python3":
 			c.JSON(200, service.RunPython3Code(req.Code, req.Preload, &runner_types.RunnerOptions{
 				EnableNetwork: req.EnableNetwork,
+				Dependencies:  req.Dependencies,
 			}))
 		case "nodejs":
 			c.JSON(200, service.RunNodeJsCode(req.Code, req.Preload, &runner_types.RunnerOptions{
 				EnableNetwork: req.EnableNetwork,
+				Dependencies:  req.Dependencies,
 			}))
 		default:
 			c.JSON(400, types.ErrorResponse(-400, "unsupported language"))

--- a/internal/core/runner/python/dependencies/uv.go
+++ b/internal/core/runner/python/dependencies/uv.go
@@ -1,0 +1,5 @@
+package dependencies
+
+func init() {
+	SetupDependency("uv", "")
+}

--- a/internal/core/runner/python/prescript.py
+++ b/internal/core/runner/python/prescript.py
@@ -29,6 +29,12 @@ key = b64decode(key)
 
 os.chdir(running_path)
 
+# because DifySeccomp will chroot to running path
+# we need fix sys.path
+for i, path in enumerate(sys.path):
+    if path.startswith(running_path):
+        sys.path[i] = path.replace(running_path, "")
+
 {{preload}}
 
 lib.DifySeccomp({{uid}}, {{gid}}, {{enable_network}})

--- a/internal/core/runner/temp_dir.go
+++ b/internal/core/runner/temp_dir.go
@@ -18,7 +18,7 @@ func (s *TempDirRunner) WithTempDir(basedir string, paths []string, closures fun
 
 	// create a tmp dir
 	tmp_dir := path.Join(basedir, "tmp", "sandbox-"+uuid.String())
-	err = os.Mkdir(tmp_dir, 0755)
+	err = os.MkdirAll(tmp_dir, 0755)
 	if err != nil {
 		return err
 	}

--- a/internal/core/runner/types/runner_options.go
+++ b/internal/core/runner/types/runner_options.go
@@ -8,7 +8,8 @@ type Dependency struct {
 }
 
 type RunnerOptions struct {
-	EnableNetwork bool `json:"enable_network"`
+	EnableNetwork bool         `json:"enable_network"`
+	Dependencies  []Dependency `json:"dependencies"`
 }
 
 func (r *RunnerOptions) Json() string {

--- a/internal/service/check.go
+++ b/internal/service/check.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	ErrNetworkDisabled = errors.New("network is disabled, please enable it in the configuration")
+	ErrNetworkDisabled            = errors.New("network is disabled, please enable it in the configuration")
+	ErrCustomDependenciesDisabled = errors.New("custom dependencies are disabled, please enable it in the configuration")
 )
 
 func checkOptions(options *types.RunnerOptions) error {
@@ -16,6 +17,10 @@ func checkOptions(options *types.RunnerOptions) error {
 
 	if options.EnableNetwork && !configuration.EnableNetwork {
 		return ErrNetworkDisabled
+	}
+
+	if !configuration.EnableCustomDependencies && len(options.Dependencies) > 0 {
+		return ErrCustomDependenciesDisabled
 	}
 
 	return nil

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -17,6 +17,7 @@ type DifySandboxGlobalConfigurations struct {
 	EnableNetwork            bool     `yaml:"enable_network"`
 	EnablePreload            bool     `yaml:"enable_preload"`
 	AllowedSyscalls          []int    `yaml:"allowed_syscalls"`
+	EnableCustomDependencies bool     `yaml:"enable_custom_dependencies"`
 	Proxy                    struct {
 		Socks5 string `yaml:"socks5"`
 		Https  string `yaml:"https"`

--- a/tests/integration_tests/conf/config.yaml
+++ b/tests/integration_tests/conf/config.yaml
@@ -22,6 +22,7 @@ python_lib_path:
   - "/usr/share/zoneinfo"
   - "/etc/timezone"
 enable_network: True # please make sure there is no network risk in your environment
+enable_custom_dependencies: True # allow installing custom dependencies from http requests, please make sure there is no risk
 allowed_syscalls: # please leave it empty if you have no idea how seccomp works
 proxy:
   socks5: ''

--- a/tests/integration_tests/python_feature_test.go
+++ b/tests/integration_tests/python_feature_test.go
@@ -101,6 +101,35 @@ print(httpx.get("https://www.bilibili.com").content)
 	})
 }
 
+func TestPythonWithCustomDependencies(t *testing.T) {
+	// Test case for http
+	runMultipleTestings(t, 1, func(t *testing.T) {
+		resp := service.RunPython3Code(`
+import yaml
+print(yaml.safe_load('a: \n    b')['a'])
+	`, "", &types.RunnerOptions{
+			EnableNetwork: true,
+			Dependencies: []types.Dependency{
+				{
+					Name:    "pyyaml",
+					Version: "",
+				},
+			},
+		})
+		if resp.Code != 0 {
+			t.Fatal(resp)
+		}
+
+		if resp.Data.(*service.RunCodeResponse).Stderr != "" {
+			t.Fatalf("unexpected error: %s\n", resp.Data.(*service.RunCodeResponse).Stderr)
+		}
+
+		if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stdout, "b") {
+			t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
+		}
+	})
+}
+
 func TestPythonTimezone(t *testing.T) {
 	// Test case for time
 	runMultipleTestings(t, 1, func(t *testing.T) {


### PR DESCRIPTION
This pr adds the ability for client to request install custom python dependencies for this instance. To achieve that, we use [astral-sh/uv](https://github.com/astral-sh/uv) to create and manage python virtual environment. To not interfere current implementation, the venv will be only created when `enable_custom_dependencies` is on and custom dependencies are requested. We also add `--system-site-packages` on venv creation so that the instance can use installed packages such as `requests` and `httpx`.