### PR TITLE
fix: resolve duplicate logging 

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,10 @@ func initConfig() {
 func initServer() {
 	config := static.GetDifySandboxGlobalConfigurations()
 
+	if !config.App.Debug {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
 	r := gin.Default()
 	controller.Setup(r)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,16 +28,8 @@ func initConfig() {
 
 func initServer() {
 	config := static.GetDifySandboxGlobalConfigurations()
-	if !config.App.Debug {
-		gin.SetMode(gin.ReleaseMode)
-	}
 
 	r := gin.Default()
-	r.Use(gin.Recovery())
-	if gin.Mode() == gin.DebugMode {
-		r.Use(gin.Logger())
-	}
-
 	controller.Setup(r)
 
 	r.Run(fmt.Sprintf(":%d", config.App.Port))
@@ -69,7 +61,7 @@ func initDependencies() {
 		}
 		ticker := time.NewTicker(tickerDuration)
 		for range ticker.C {
-			if err:=updatePythonDependencies(dependencies);err!=nil{
+			if err := updatePythonDependencies(dependencies); err != nil {
 				log.Error("Failed to update Python dependencies: %v", err)
 			}
 		}


### PR DESCRIPTION
1. **Duplicate Log Entries**: Each request is logged twice
   - `gin.Default()` already includes the `Logger` middleware
   - In Debug mode, `gin.Logger()` was added again, causing duplicate logs

## Reproduction
```yaml
app:
  port: 8194
  debug: True
  key: dify-sandbox
max_workers: 4
max_requests: 50
worker_timeout: 5
python_path: /usr/local/bin/python3
enable_network: True # please make sure there is no network risk in your environment
enable_preload: False # please keep it as False for security purposes
allowed_syscalls: # please leave it empty if you have no idea how seccomp works
proxy:
  socks5: ''
  http: ''
  https: ''
```

```bash
curl -s -X POST http://localhost:8194/v1/sandbox/run \
  -H "Content-Type: application/json" \
  -H "X-Api-Key: dify-sandbox" \
  -d '{
    "language": "python3",
    "code": "print(\"Hello from Dify Sandbox!\")\nprint(1 + 1)",
    "enable_network": false
  }'
```

[GIN] 2025/11/17 - 03:42:24 | 200 | 110.582µs | 172.17.0.1 | POST "/v1/sandbox/run"
[GIN] 2025/11/17 - 03:42:24 | 200 | 133.045µs | 172.17.0.1 | POST "/v1/sandbox/run"