### PR TITLE
fix http status code

### DIFF
--- a/internal/controller/base.go
+++ b/internal/controller/base.go
@@ -11,7 +11,7 @@ func BindRequest[T any](r *gin.Context, success func(T)) {
 
 	context_type := r.GetHeader("Content-Type")
 	if context_type == "application/json" {
-		err = r.BindJSON(&request)
+		err = r.ShouldBindJSON(&request)
 	} else {
 		err = r.ShouldBind(&request)
 	}


### PR DESCRIPTION
err = r.BindJSON(&request) will write http header to client if err. After this, r.JSON(200, resp) willl cause warning `Headers were already written. Wanted to override status code 400 with 200`


```
[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 400 with 200
[GIN] 2025/11/17 - 03:42:24 | 400 | 110.582µs | 172.17.0.1 | POST "/v1/sandbox/run"
[GIN] 2025/11/17 - 03:42:24 | 400 | 133.045µs | 172.17.0.1 | POST "/v1/sandbox/run"
```