### PR TITLE
feat: support sandbox env

### DIFF
--- a/internal/core/runner/nodejs/nodejs.go
+++ b/internal/core/runner/nodejs/nodejs.go
@@ -71,6 +71,10 @@ func (p *NodeJsRunner) Run(
 		)
 		cmd.Env = []string{}
 
+		for key, value := range configuration.SandboxEnvs {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+		}
+
 		if len(configuration.AllowedSyscalls) > 0 {
 			cmd.Env = append(
 				cmd.Env,

--- a/internal/core/runner/python/python.go
+++ b/internal/core/runner/python/python.go
@@ -65,6 +65,10 @@ func (p *PythonRunner) Run(
 	cmd.Env = []string{}
 	cmd.Dir = LIB_PATH
 
+	for key, value := range configuration.SandboxEnvs {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
+
 	if configuration.Proxy.Socks5 != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTPS_PROXY=%s", configuration.Proxy.Socks5))
 		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTP_PROXY=%s", configuration.Proxy.Socks5))

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -154,6 +154,17 @@ func InitConfig(path string) error {
 			slog.Info("using http proxy", "proxy", difySandboxGlobalConfigurations.Proxy.Http)
 		}
 	}
+	if difySandboxGlobalConfigurations.SandboxEnvs == nil {
+		difySandboxGlobalConfigurations.SandboxEnvs = make(map[string]string)
+	}
+	for _, env := range os.Environ() {
+		kv := strings.SplitN(env, "=", 2)
+		if len(kv) == 2 && strings.HasPrefix(kv[0], "SANDBOX_ENV_") {
+			key := strings.TrimPrefix(kv[0], "SANDBOX_ENV_")
+			value := kv[1]
+			difySandboxGlobalConfigurations.SandboxEnvs[key] = value
+		}
+	}
 	return nil
 }
 

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -6,18 +6,19 @@ type DifySandboxGlobalConfigurations struct {
 		Debug bool   `yaml:"debug"`
 		Key   string `yaml:"key"`
 	} `yaml:"app"`
-	MaxWorkers               int      `yaml:"max_workers"`
-	MaxRequests              int      `yaml:"max_requests"`
-	WorkerTimeout            int      `yaml:"worker_timeout"`
-	PythonPath               string   `yaml:"python_path"`
-	PythonLibPaths           []string `yaml:"python_lib_path"`
-	PythonPipMirrorURL       string   `yaml:"python_pip_mirror_url"`
-	PythonDepsUpdateInterval string   `yaml:"python_deps_update_interval"`
-	NodejsPath               string   `yaml:"nodejs_path"`
-	EnableNetwork            bool     `yaml:"enable_network"`
-	EnablePreload            bool     `yaml:"enable_preload"`
-	AllowedSyscalls          []int    `yaml:"allowed_syscalls"`
-	LogPath                  string   `yaml:"log_path"`
+	MaxWorkers               int               `yaml:"max_workers"`
+	MaxRequests              int               `yaml:"max_requests"`
+	WorkerTimeout            int               `yaml:"worker_timeout"`
+	PythonPath               string            `yaml:"python_path"`
+	PythonLibPaths           []string          `yaml:"python_lib_path"`
+	PythonPipMirrorURL       string            `yaml:"python_pip_mirror_url"`
+	PythonDepsUpdateInterval string            `yaml:"python_deps_update_interval"`
+	NodejsPath               string            `yaml:"nodejs_path"`
+	EnableNetwork            bool              `yaml:"enable_network"`
+	EnablePreload            bool              `yaml:"enable_preload"`
+	AllowedSyscalls          []int             `yaml:"allowed_syscalls"`
+	LogPath                  string            `yaml:"log_path"`
+	SandboxEnvs              map[string]string `yaml:"sandbox_envs"`
 	Proxy                    struct {
 		Socks5 string `yaml:"socks5"`
 		Https  string `yaml:"https"`


### PR DESCRIPTION
Using the SANDBOX_ENV_ prefix to add global sandbox environment variables. For example, it can be used to configure the PYTHONWARNINGS variable to suppress unexpected stderr output.