### PR TITLE
fix(controller): return 400 when request binding fails

### DIFF
--- a/internal/controller/base.go
+++ b/internal/controller/base.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/langgenius/dify-sandbox/internal/types"
 )
@@ -18,7 +20,7 @@ func BindRequest[T any](r *gin.Context, success func(T)) {
 
 	if err != nil {
 		resp := types.ErrorResponse(-400, err.Error())
-		r.JSON(200, resp)
+		r.JSON(http.StatusBadRequest, resp)
 		return
 	}
 	success(request)

--- a/internal/controller/base_test.go
+++ b/internal/controller/base_test.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/langgenius/dify-sandbox/internal/types"
+)
+
+func TestBindRequestReturnsBadRequestWhenJSONIsInvalid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/sandbox/run", strings.NewReader(`{"language"`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	successCalled := false
+	BindRequest(ctx, func(req struct {
+		Language string `json:"language" binding:"required"`
+	}) {
+		successCalled = true
+	})
+
+	if successCalled {
+		t.Fatalf("success callback should not be called when request binding fails")
+	}
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+
+	var resp types.DifySandboxResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response body: %v", err)
+	}
+
+	if resp.Code != -400 {
+		t.Fatalf("expected response code -400, got %d", resp.Code)
+	}
+}


### PR DESCRIPTION
## Problem
When request binding fails, the API returns business code `-400` but HTTP status `200`.

## Fix
- Change binding failure response status from `200` to `400` in `BindRequest`.
- Add a regression test for invalid JSON payload.

## Why it matters
This aligns with standard HTTP semantics and makes failures easier to handle by gateways, SDKs, and monitoring.

## Test
- Added test: `TestBindRequestReturnsBadRequestWhenJSONIsInvalid`