### PR TITLE
fix: prevent interactive dpkg prompts in Debian installs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,10 @@ jobs:
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install System Dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y \
             -o Dpkg::Options::="--force-confdef" \
             -o Dpkg::Options::="--force-confold" \
             pkg-config gcc libseccomp-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,11 @@ jobs:
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install System Dependencies
-        run: sudo apt-get install -y pkg-config gcc libseccomp-dev
+        run: |
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            -o Dpkg::Options::="--force-confdef" \
+            -o Dpkg::Options::="--force-confold" \
+            pkg-config gcc libseccomp-dev
 
       - name: Install yq for version configuration
         run: |

--- a/docker/templates/base.dockerfile
+++ b/docker/templates/base.dockerfile
@@ -8,7 +8,9 @@ ARG DEBIAN_MIRROR="http://deb.debian.org/debian testing main"
 # Install system dependencies
 RUN echo "deb ${DEBIAN_MIRROR}" > /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       -o Dpkg::Options::="--force-confdef" \
+       -o Dpkg::Options::="--force-confold" \
        pkg-config \
        libseccomp-dev \
        wget \

--- a/docker/templates/base.dockerfile
+++ b/docker/templates/base.dockerfile
@@ -1,6 +1,7 @@
 # Base Dockerfile template - shared system dependencies installation logic
 ARG PYTHON_VERSION=dhi.io/python:3-debian13-sfw-ent-dev
 FROM ${PYTHON_VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Build arguments
 ARG DEBIAN_MIRROR="http://deb.debian.org/debian testing main"
@@ -8,7 +9,7 @@ ARG DEBIAN_MIRROR="http://deb.debian.org/debian testing main"
 # Install system dependencies
 RUN echo "deb ${DEBIAN_MIRROR}" > /etc/apt/sources.list \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
        -o Dpkg::Options::="--force-confdef" \
        -o Dpkg::Options::="--force-confold" \
        pkg-config \

--- a/docker/templates/production.dockerfile
+++ b/docker/templates/production.dockerfile
@@ -11,7 +11,9 @@ FROM ${PYTHON_VERSION}
 # Install system dependencies
 RUN echo "deb ${DEBIAN_MIRROR}" > /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       -o Dpkg::Options::="--force-confdef" \
+       -o Dpkg::Options::="--force-confold" \
        pkg-config \
        libseccomp-dev \
        wget \

--- a/docker/templates/production.dockerfile
+++ b/docker/templates/production.dockerfile
@@ -7,11 +7,12 @@ ARG NODEJS_MIRROR="https://npmmirror.com/mirrors/node"
 ARG TARGETARCH
 
 FROM ${PYTHON_VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies
 RUN echo "deb ${DEBIAN_MIRROR}" > /etc/apt/sources.list \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
        -o Dpkg::Options::="--force-confdef" \
        -o Dpkg::Options::="--force-confold" \
        pkg-config \

--- a/docker/templates/test.dockerfile
+++ b/docker/templates/test.dockerfile
@@ -10,13 +10,14 @@ ARG TARGETARCH
 
 # Build stage
 FROM golang:${GOLANG_VERSION} AS builder
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY . /app
 WORKDIR /app
 
 # Install build dependencies and build
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    && apt-get install -y \
        -o Dpkg::Options::="--force-confdef" \
        -o Dpkg::Options::="--force-confold" \
        pkg-config gcc libseccomp-dev \
@@ -29,6 +30,7 @@ RUN apt-get update \
 
 # Test stage
 FROM ${PYTHON_VERSION} as tester
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG DEBIAN_MIRROR
 ARG PYTHON_PACKAGES
@@ -41,7 +43,7 @@ ARG TARGETARCH
 # Install system dependencies
 RUN echo "deb ${DEBIAN_MIRROR}" > /etc/apt/sources.list \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
        -o Dpkg::Options::="--force-confdef" \
        -o Dpkg::Options::="--force-confold" \
        pkg-config \

--- a/docker/templates/test.dockerfile
+++ b/docker/templates/test.dockerfile
@@ -15,7 +15,11 @@ COPY . /app
 WORKDIR /app
 
 # Install build dependencies and build
-RUN apt-get update && apt-get install -y pkg-config gcc libseccomp-dev \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+       -o Dpkg::Options::="--force-confdef" \
+       -o Dpkg::Options::="--force-confold" \
+       pkg-config gcc libseccomp-dev \
     && go mod tidy \
     && case "${TARGETARCH}" in \
        "amd64") bash ./build/build_amd64.sh ;; \
@@ -37,7 +41,9 @@ ARG TARGETARCH
 # Install system dependencies
 RUN echo "deb ${DEBIAN_MIRROR}" > /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       -o Dpkg::Options::="--force-confdef" \
+       -o Dpkg::Options::="--force-confold" \
        pkg-config \
        libseccomp-dev \
        wget \

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 # check if ubuntu/debain
 if [ -f /etc/debian_version ]; then
-    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    export DEBIAN_FRONTEND=noninteractive
+    sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y \
         -o Dpkg::Options::="--force-confdef" \
         -o Dpkg::Options::="--force-confold" \
         pkg-config gcc libseccomp-dev

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 # check if ubuntu/debain
 if [ -f /etc/debian_version ]; then
-    sudo apt-get install pkg-config gcc libseccomp-dev
+    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        -o Dpkg::Options::="--force-confdef" \
+        -o Dpkg::Options::="--force-confold" \
+        pkg-config gcc libseccomp-dev
 # check if fedora
 elif [ -f /etc/fedora-release ]; then
     sudo dnf install pkgconfig gcc libseccomp-devel

--- a/internal/core/runner/nodejs/nodejs.h
+++ b/internal/core/runner/nodejs/nodejs.h
@@ -12,6 +12,8 @@
 
 #ifndef GO_CGO_GOSTRING_TYPEDEF
 typedef struct { const char *p; ptrdiff_t n; } _GoString_;
+extern size_t _GoStringLen(_GoString_ s);
+extern const char *_GoStringPtr(_GoString_ s);
 #endif
 
 #endif
@@ -44,9 +46,15 @@ typedef size_t GoUintptr;
 typedef float GoFloat32;
 typedef double GoFloat64;
 #ifdef _MSC_VER
+#if !defined(__cplusplus) || _MSVC_LANG <= 201402L
 #include <complex.h>
 typedef _Fcomplex GoComplex64;
 typedef _Dcomplex GoComplex128;
+#else
+#include <complex>
+typedef std::complex<float> GoComplex64;
+typedef std::complex<double> GoComplex128;
+#endif
 #else
 typedef float _Complex GoComplex64;
 typedef double _Complex GoComplex128;

--- a/internal/core/runner/python/python.h
+++ b/internal/core/runner/python/python.h
@@ -12,6 +12,8 @@
 
 #ifndef GO_CGO_GOSTRING_TYPEDEF
 typedef struct { const char *p; ptrdiff_t n; } _GoString_;
+extern size_t _GoStringLen(_GoString_ s);
+extern const char *_GoStringPtr(_GoString_ s);
 #endif
 
 #endif
@@ -44,9 +46,15 @@ typedef size_t GoUintptr;
 typedef float GoFloat32;
 typedef double GoFloat64;
 #ifdef _MSC_VER
+#if !defined(__cplusplus) || _MSVC_LANG <= 201402L
 #include <complex.h>
 typedef _Fcomplex GoComplex64;
 typedef _Dcomplex GoComplex128;
+#else
+#include <complex>
+typedef std::complex<float> GoComplex64;
+typedef std::complex<double> GoComplex128;
+#endif
 #else
 typedef float _Complex GoComplex64;
 typedef double _Complex GoComplex128;


### PR DESCRIPTION
## Summary
- Run Debian package installs in Docker, CI, and local setup with `DEBIAN_FRONTEND=noninteractive`.
- Add `dpkg` conffile options to keep the existing config and avoid blocking prompts during package upgrades.
- Refresh the generated runner headers after rebuilding the binaries.

## Why
This fixes build failures caused by interactive `dpkg` conffile prompts when Debian package installs upgrade core system packages in non-interactive environments. It keeps the current config by default so Docker builds, CI jobs, and local Debian setup complete reliably.

Closes #239

**This PR is drafted by `gpt-5.4(high)` and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**

## Testing
- Built `dify-sandbox-test:latest` successfully
- Built `dify-sandbox-production:latest` successfully after generating the required local `main` and `env` binaries with `bash ./build/build_amd64.sh`
- Verified the Debian install steps no longer stop on an interactive `dpkg` conffile prompt