### PR TITLE
fix: pass sandbox user code over fd 3

### DIFF
--- a/internal/core/runner/nodejs/nodejs.go
+++ b/internal/core/runner/nodejs/nodejs.go
@@ -3,8 +3,8 @@ package nodejs
 import (
 	"context"
 	_ "embed"
-	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -51,15 +51,32 @@ func (p *NodeJsRunner) Run(
 	output_handler.SetTimeout(timeout)
 
 	err := p.WithTempDir("/", REQUIRED_FS, func(root_path string) error {
+		cleanupRootPath := true
+		defer func() {
+			if cleanupRootPath {
+				os.RemoveAll(root_path)
+			}
+		}()
+
 		output_handler.SetAfterExitHook(func() {
 			os.RemoveAll(root_path)
 		})
 
 		// initialize the environment
-		script_path, err := p.InitializeEnvironment(code, preload, root_path)
+		script_path, err := p.InitializeEnvironment(preload, root_path)
 		if err != nil {
 			return err
 		}
+
+		codeReader, codeWriter, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+		output_handler.SetAfterExitHook(func() {
+			codeReader.Close()
+			codeWriter.Close()
+			os.RemoveAll(root_path)
+		})
 
 		// create a new process
 		cmd := exec.Command(
@@ -70,6 +87,7 @@ func (p *NodeJsRunner) Run(
 			options.Json(),
 		)
 		cmd.Env = []string{}
+		cmd.ExtraFiles = []*os.File{codeReader}
 
 		if len(configuration.AllowedSyscalls) > 0 {
 			cmd.Env = append(
@@ -80,11 +98,19 @@ func (p *NodeJsRunner) Run(
 			)
 		}
 
+		go func() {
+			_, _ = io.WriteString(codeWriter, code)
+			codeWriter.Close()
+		}()
+
 		// capture the output
 		err = output_handler.CaptureOutput(ctx, cmd)
 		if err != nil {
+			codeReader.Close()
+			codeWriter.Close()
 			return err
 		}
+		cleanupRootPath = false
 
 		return nil
 	})
@@ -96,22 +122,21 @@ func (p *NodeJsRunner) Run(
 	return output_handler.GetStdout(), output_handler.GetStderr(), output_handler.GetDone(), nil
 }
 
-func (p *NodeJsRunner) InitializeEnvironment(code string, preload string, root_path string) (string, error) {
-	if !checkLibAvaliable() {
-		releaseLibBinary()
-	}
-
+func buildBootstrap(preload string) string {
 	node_sandbox_file := string(nodejs_sandbox_fs)
 	if preload != "" {
 		node_sandbox_file = fmt.Sprintf("%s\n%s", preload, node_sandbox_file)
 	}
 
-	// join nodejs_sandbox_fs and code
-	// encode code with base64
-	code = base64.StdEncoding.EncodeToString([]byte(code))
-	// FIXE: redeclared function causes code injection
-	evalCode := fmt.Sprintf("eval(Buffer.from('%s', 'base64').toString('utf-8'))", code)
-	code = node_sandbox_file + evalCode
+	return node_sandbox_file
+}
+
+func (p *NodeJsRunner) InitializeEnvironment(preload string, root_path string) (string, error) {
+	if !checkLibAvaliable() {
+		releaseLibBinary()
+	}
+
+	code := buildBootstrap(preload)
 
 	// override root_path/tmp/sandbox-nodejs-project/prescript.js
 	script_path := path.Join(root_path, LIB_PATH, PROJECT_NAME, "node_temp/node_temp/test.js")

--- a/internal/core/runner/nodejs/nodejs_test.go
+++ b/internal/core/runner/nodejs/nodejs_test.go
@@ -1,0 +1,22 @@
+package nodejs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildBootstrapInjectsPreloadButNotUserCode(t *testing.T) {
+	bootstrap := buildBootstrap("globalThis.preloaded = true;")
+
+	if !strings.Contains(bootstrap, "globalThis.preloaded = true;") {
+		t.Fatal("expected preload in bootstrap")
+	}
+
+	if !strings.Contains(bootstrap, "readFileSync(3, 'utf8')") {
+		t.Fatal("expected bootstrap to read code from fd 3")
+	}
+
+	if strings.Contains(bootstrap, "console.log('user code')") {
+		t.Fatal("bootstrap unexpectedly contains user code")
+	}
+}

--- a/internal/core/runner/nodejs/prescript.js
+++ b/internal/core/runner/nodejs/prescript.js
@@ -1,4 +1,5 @@
 const argv = process.argv
+const fs = require('fs')
 
 const koffi = require('koffi')
 const lib = koffi.load('./var/sandbox/sandbox-nodejs/nodejs.so')
@@ -11,3 +12,5 @@ const options = JSON.parse(argv[4])
 
 difySeccomp(uid, gid, options['enable_network'])
 
+const code = fs.readFileSync(3, 'utf8')
+eval(code)

--- a/internal/core/runner/python/prescript.py
+++ b/internal/core/runner/python/prescript.py
@@ -2,11 +2,14 @@ import ctypes
 import os
 import sys
 import traceback
+
+
 # setup sys.excepthook
 def excepthook(type, value, tb):
     sys.stderr.write("".join(traceback.format_exception(type, value, tb)))
     sys.stderr.flush()
     sys.exit(-1)
+
 
 sys.excepthook = excepthook
 
@@ -19,29 +22,13 @@ running_path = sys.argv[1]
 if not running_path:
     exit(-1)
 
-# get decrypt key
-key = sys.argv[2]
-if not key:
-    exit(-1)
-
-from base64 import b64decode
-key = b64decode(key)
-
 os.chdir(running_path)
 
 {{preload}}
 
 lib.DifySeccomp({{uid}}, {{gid}}, {{enable_network}})
 
-code = b64decode("{{code}}")
+with os.fdopen(3, "rb") as code_fd:
+    code = code_fd.read().decode("utf-8")
 
-def decrypt(code, key):
-    key_len = len(key)
-    code_len = len(code)
-    code = bytearray(code)
-    for i in range(code_len):
-        code[i] = code[i] ^ key[i % key_len]
-    return bytes(code)
-
-code = decrypt(code, key)
-exec(code)
+exec(compile(code, "<fd3>", "exec"))

--- a/internal/core/runner/python/python.go
+++ b/internal/core/runner/python/python.go
@@ -2,10 +2,9 @@ package python
 
 import (
 	"context"
-	"crypto/rand"
 	_ "embed"
-	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -42,8 +41,15 @@ func (p *PythonRunner) Run(
 		return nil, nil, nil, fmt.Errorf("no available sandbox UID: %w", err)
 	}
 
-	untrustedCodePath, key, err := p.InitializeEnvironment(code, preload, options, uid)
+	bootstrapPath, err := p.InitializeEnvironment(preload, options, uid)
 	if err != nil {
+		ReleaseUID(uid)
+		return nil, nil, nil, err
+	}
+
+	codeReader, codeWriter, err := os.Pipe()
+	if err != nil {
+		os.Remove(bootstrapPath)
 		ReleaseUID(uid)
 		return nil, nil, nil, err
 	}
@@ -51,19 +57,21 @@ func (p *PythonRunner) Run(
 	outputHandler := runner.NewOutputCaptureRunner()
 	outputHandler.SetTimeout(timeout)
 	outputHandler.SetAfterExitHook(func() {
-		os.Remove(untrustedCodePath)
+		codeReader.Close()
+		codeWriter.Close()
+		os.Remove(bootstrapPath)
 		ReleaseUID(uid)
 	})
 
 	// create a new process
 	cmd := exec.Command(
 		configuration.PythonPath,
-		untrustedCodePath,
+		bootstrapPath,
 		LIB_PATH,
-		key,
 	)
 	cmd.Env = []string{}
 	cmd.Dir = LIB_PATH
+	cmd.ExtraFiles = []*os.File{codeReader}
 
 	if configuration.Proxy.Socks5 != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTPS_PROXY=%s", configuration.Proxy.Socks5))
@@ -85,9 +93,16 @@ func (p *PythonRunner) Run(
 		)
 	}
 
+	go func() {
+		_, _ = io.WriteString(codeWriter, code)
+		codeWriter.Close()
+	}()
+
 	err = outputHandler.CaptureOutput(ctx, cmd)
 	if err != nil {
-		os.Remove(untrustedCodePath)
+		codeReader.Close()
+		codeWriter.Close()
+		os.Remove(bootstrapPath)
 		ReleaseUID(uid)
 		return nil, nil, nil, err
 	}
@@ -95,14 +110,7 @@ func (p *PythonRunner) Run(
 	return outputHandler.GetStdout(), outputHandler.GetStderr(), outputHandler.GetDone(), nil
 }
 
-func (p *PythonRunner) InitializeEnvironment(code string, preload string, options *types.RunnerOptions, uid int) (string, string, error) {
-	if !checkLibAvaliable() {
-		releaseLibBinary(false)
-	}
-
-	tempCodeName := strings.ReplaceAll(uuid.New().String(), "-", "_")
-	tempCodeName = strings.ReplaceAll(tempCodeName, "/", ".")
-
+func buildBootstrap(preload string, options *types.RunnerOptions, uid int) string {
 	script := strings.Replace(
 		string(sandbox_fs),
 		"{{uid}}", strconv.Itoa(uid), 1,
@@ -125,52 +133,37 @@ func (p *PythonRunner) InitializeEnvironment(code string, preload string, option
 		)
 	}
 
-	script = strings.Replace(
+	return strings.Replace(
 		script,
 		"{{preload}}",
 		fmt.Sprintf("%s\n", preload),
 		1,
 	)
+}
 
-	// generate a random 512 bit key
-	key_len := 64
-	key := make([]byte, key_len)
-	_, err := rand.Read(key)
+func (p *PythonRunner) InitializeEnvironment(preload string, options *types.RunnerOptions, uid int) (string, error) {
+	if !checkLibAvaliable() {
+		releaseLibBinary(false)
+	}
+
+	tempCodeName := strings.ReplaceAll(uuid.New().String(), "-", "_")
+	tempCodeName = strings.ReplaceAll(tempCodeName, "/", ".")
+
+	script := buildBootstrap(preload, options, uid)
+
+	bootstrapPath := fmt.Sprintf("%s/tmp/%s.py", LIB_PATH, tempCodeName)
+	err := os.MkdirAll(path.Dir(bootstrapPath), 0755)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
-
-	// encrypt the code
-	encrypted_code := make([]byte, len(code))
-	for i := 0; i < len(code); i++ {
-		encrypted_code[i] = code[i] ^ key[i%key_len]
-	}
-
-	// encode code using base64
-	code = base64.StdEncoding.EncodeToString(encrypted_code)
-	// encode key using base64
-	encodedKey := base64.StdEncoding.EncodeToString(key)
-
-	code = strings.Replace(
-		script,
-		"{{code}}",
-		code,
-		1,
-	)
-
-	untrustedCodePath := fmt.Sprintf("%s/tmp/%s.py", LIB_PATH, tempCodeName)
-	err = os.MkdirAll(path.Dir(untrustedCodePath), 0755)
+	err = os.WriteFile(bootstrapPath, []byte(script), 0600)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
-	err = os.WriteFile(untrustedCodePath, []byte(code), 0600)
-	if err != nil {
-		return "", "", err
-	}
-	if err = syscall.Chown(untrustedCodePath, uid, static.SANDBOX_GROUP_ID); err != nil {
-		os.Remove(untrustedCodePath)
-		return "", "", fmt.Errorf("chown script to uid %d: %w", uid, err)
+	if err = syscall.Chown(bootstrapPath, uid, static.SANDBOX_GROUP_ID); err != nil {
+		os.Remove(bootstrapPath)
+		return "", fmt.Errorf("chown script to uid %d: %w", uid, err)
 	}
 
-	return untrustedCodePath, encodedKey, nil
+	return bootstrapPath, nil
 }

--- a/internal/core/runner/python/python_test.go
+++ b/internal/core/runner/python/python_test.go
@@ -1,0 +1,24 @@
+package python
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
+)
+
+func TestBuildBootstrapInjectsPreloadButNotUserCode(t *testing.T) {
+	bootstrap := buildBootstrap("print('preload')", &types.RunnerOptions{EnableNetwork: true}, 123)
+
+	if !strings.Contains(bootstrap, "print('preload')") {
+		t.Fatal("expected preload in bootstrap")
+	}
+
+	if !strings.Contains(bootstrap, "os.fdopen(3") {
+		t.Fatal("expected bootstrap to read code from fd 3")
+	}
+
+	if strings.Contains(bootstrap, "print('user code')") {
+		t.Fatal("bootstrap unexpectedly contains user code")
+	}
+}

--- a/tests/integration_tests/nodejs_feature_test.go
+++ b/tests/integration_tests/nodejs_feature_test.go
@@ -80,3 +80,23 @@ console.log(JSON.stringify({"hello": "world"}));
 		}
 	})
 }
+
+func TestNodejsFd3Transport(t *testing.T) {
+	resp := service.RunNodeJsCode(context.TODO(), `
+const marker = "fd3-transport";
+console.log(marker);
+	`, "", &types.RunnerOptions{
+		EnableNetwork: true,
+	})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	if resp.Data.(*service.RunCodeResponse).Stderr != "" {
+		t.Fatalf("unexpected error: %s\n", resp.Data.(*service.RunCodeResponse).Stderr)
+	}
+
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stdout, "fd3-transport") {
+		t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
+	}
+}

--- a/tests/integration_tests/python_feature_test.go
+++ b/tests/integration_tests/python_feature_test.go
@@ -131,3 +131,23 @@ print(datetime.now(ZoneInfo("Asia/Shanghai")).isoformat())
 		}
 	})
 }
+
+func TestPythonFd3Transport(t *testing.T) {
+	resp := service.RunPython3Code(context.TODO(), `
+marker = "fd3-transport"
+print(marker)
+	`, "", &types.RunnerOptions{
+		EnableNetwork: true,
+	})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	if resp.Data.(*service.RunCodeResponse).Stderr != "" {
+		t.Fatalf("unexpected error: %s\n", resp.Data.(*service.RunCodeResponse).Stderr)
+	}
+
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stdout, "fd3-transport") {
+		t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
+	}
+}


### PR DESCRIPTION
## Summary
- stop persisting the main Python and Node.js user payload in generated bootstrap scripts
- pass the main untrusted payload over inherited FD 3 after sandbox setup instead of embedding it on disk
- add runner and integration test coverage for the updated FD 3 execution path

## Why
This change reduces exposure of untrusted sandbox code by removing the old on-disk payload flow from both runtimes and aligning Python and Node.js on the same safer execution model.

Closes #241

**This PR is drafted by `gpt-5.4(high)` and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**

## Testing
- added Python and Node.js runner tests for the FD 3 bootstrap path
- added integration tests covering Python and Node.js FD 3 execution
- validated affected packages and tests compile with `go test -exec /bin/true ./internal/core/runner/python ./internal/core/runner/nodejs ./tests/integration_tests`
- full runtime sandbox tests still require an environment that supports sandbox user setup during init