### PR TITLE
fix: abort failed sandbox setup and correct privilege drop order

### DIFF
--- a/cmd/lib/nodejs/main.go
+++ b/cmd/lib/nodejs/main.go
@@ -5,7 +5,9 @@ import "C"
 
 //export DifySeccomp
 func DifySeccomp(uid int, gid int, enable_network bool) {
-	nodejs.InitSeccomp(uid, gid, enable_network)
+	if err := nodejs.InitSeccomp(uid, gid, enable_network); err != nil {
+		panic(err)
+	}
 }
 
 func main() {}

--- a/cmd/lib/python/main.go
+++ b/cmd/lib/python/main.go
@@ -7,7 +7,9 @@ import "C"
 
 //export DifySeccomp
 func DifySeccomp(uid int, gid int, enable_network bool) {
-	python.InitSeccomp(uid, gid, enable_network)
+	if err := python.InitSeccomp(uid, gid, enable_network); err != nil {
+		panic(err)
+	}
 }
 
 func main() {}

--- a/internal/core/lib/nodejs/add_seccomp.go
+++ b/internal/core/lib/nodejs/add_seccomp.go
@@ -39,6 +39,7 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 			}
 			allowed_syscalls = append(allowed_syscalls, syscall)
 		}
+		allowed_syscalls = append(allowed_syscalls, syscall.SYS_SETGROUPS)
 	} else {
 		allowed_syscalls = append(allowed_syscalls, nodejs_syscall.ALLOW_SYSCALLS...)
 		allowed_not_kill_syscalls = append(allowed_not_kill_syscalls, nodejs_syscall.ALLOW_ERROR_SYSCALLS...)
@@ -53,14 +54,19 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 		return err
 	}
 
-	// setuid
-	err = syscall.Setuid(uid)
+	err = syscall.Setgroups([]int{})
 	if err != nil {
 		return err
 	}
 
 	// setgid
 	err = syscall.Setgid(gid)
+	if err != nil {
+		return err
+	}
+
+	// setuid
+	err = syscall.Setuid(uid)
 	if err != nil {
 		return err
 	}

--- a/internal/core/lib/python/add_seccomp.go
+++ b/internal/core/lib/python/add_seccomp.go
@@ -40,6 +40,7 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 			}
 			allowed_syscalls = append(allowed_syscalls, syscall)
 		}
+		allowed_syscalls = append(allowed_syscalls, syscall.SYS_SETGROUPS)
 	} else {
 		allowed_syscalls = append(allowed_syscalls, python_syscall.ALLOW_SYSCALLS...)
 		if enable_network {
@@ -52,14 +53,19 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 		return err
 	}
 
-	// setuid
-	err = syscall.Setuid(uid)
+	err = syscall.Setgroups([]int{})
 	if err != nil {
 		return err
 	}
 
 	// setgid
 	err = syscall.Setgid(gid)
+	if err != nil {
+		return err
+	}
+
+	// setuid
+	err = syscall.Setuid(uid)
 	if err != nil {
 		return err
 	}

--- a/internal/static/nodejs_syscall/syscalls_amd64.go
+++ b/internal/static/nodejs_syscall/syscalls_amd64.go
@@ -29,7 +29,7 @@ var ALLOW_SYSCALLS = []int{
 	syscall.SYS_SCHED_GETAFFINITY, syscall.SYS_SET_ROBUST_LIST,
 	SYS_RSEQ,
 
-	syscall.SYS_SETUID, syscall.SYS_SETGID, syscall.SYS_GETTID,
+	syscall.SYS_SETGROUPS, syscall.SYS_SETGID, syscall.SYS_SETUID, syscall.SYS_GETTID,
 
 	syscall.SYS_CLOCK_GETTIME, syscall.SYS_GETTIMEOFDAY, syscall.SYS_NANOSLEEP,
 	syscall.SYS_TIME,

--- a/internal/static/nodejs_syscall/syscalls_arm64.go
+++ b/internal/static/nodejs_syscall/syscalls_arm64.go
@@ -22,7 +22,7 @@ var ALLOW_SYSCALLS = []int{
 	syscall.SYS_RT_SIGRETURN, syscall.SYS_BRK,
 
 	//user/group
-	syscall.SYS_SETUID, syscall.SYS_SETGID, syscall.SYS_GETTID,
+	syscall.SYS_SETGROUPS, syscall.SYS_SETGID, syscall.SYS_SETUID, syscall.SYS_GETTID,
 	syscall.SYS_GETUID, syscall.SYS_GETGID,
 
 	// epoll

--- a/internal/static/python_syscall/syscalls_amd64.go
+++ b/internal/static/python_syscall/syscalls_amd64.go
@@ -21,7 +21,7 @@ var ALLOW_SYSCALLS = []int{
 	syscall.SYS_MREMAP,
 
 	// user/group
-	syscall.SYS_SETUID, syscall.SYS_SETGID, syscall.SYS_GETUID,
+	syscall.SYS_SETGROUPS, syscall.SYS_SETGID, syscall.SYS_SETUID, syscall.SYS_GETUID,
 	// process
 	syscall.SYS_GETPID, syscall.SYS_GETPPID, syscall.SYS_GETTID,
 	syscall.SYS_EXIT, syscall.SYS_EXIT_GROUP,

--- a/internal/static/python_syscall/syscalls_arm64.go
+++ b/internal/static/python_syscall/syscalls_arm64.go
@@ -23,7 +23,7 @@ var ALLOW_SYSCALLS = []int{
 	syscall.SYS_SIGALTSTACK, syscall.SYS_MREMAP,
 
 	// user/group
-	syscall.SYS_SETUID, syscall.SYS_SETGID, syscall.SYS_GETUID,
+	syscall.SYS_SETGROUPS, syscall.SYS_SETGID, syscall.SYS_SETUID, syscall.SYS_GETUID,
 
 	// process
 	syscall.SYS_GETPID, syscall.SYS_GETPPID, syscall.SYS_GETTID,


### PR DESCRIPTION
## Summary
- abort Python and Node sandbox setup when `InitSeccomp(...)` fails in the exported wrappers
- drop privileges in the safer `setgroups -> setgid -> setuid` order
- allow `SYS_SETGROUPS` in both default and `ALLOWED_SYSCALLS` override seccomp paths

## Why
Sandbox setup should stop immediately when security initialization fails, and the privilege drop sequence needs to clear supplementary groups before gid/uid changes without being blocked by seccomp.

Closes #248

**This PR is drafted by `gpt-5.4(high)` and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**

## Testing
- validated affected packages with `go test ./cmd/lib/python ./cmd/lib/nodejs ./internal/core/lib/python ./internal/core/lib/nodejs ./internal/static/python_syscall ./internal/static/nodejs_syscall`
- full runtime seccomp/chroot behavior still needs a Linux integration environment that can execute the sandbox setup path