### PR TITLE
fix: allow python fd3 reads under seccomp

### DIFF
--- a/internal/static/python_syscall/syscalls_amd64.go
+++ b/internal/static/python_syscall/syscalls_amd64.go
@@ -12,7 +12,7 @@ const (
 
 var ALLOW_SYSCALLS = []int{
 	// file io
-	syscall.SYS_NEWFSTATAT, syscall.SYS_IOCTL, syscall.SYS_LSEEK, syscall.SYS_GETDENTS64,
+	syscall.SYS_NEWFSTATAT, syscall.SYS_FSTAT, syscall.SYS_FCNTL, syscall.SYS_IOCTL, syscall.SYS_LSEEK, syscall.SYS_GETDENTS64,
 	syscall.SYS_WRITE, syscall.SYS_CLOSE, syscall.SYS_OPENAT, syscall.SYS_READ,
 	// thread
 	syscall.SYS_FUTEX,

--- a/internal/static/python_syscall/syscalls_arm64.go
+++ b/internal/static/python_syscall/syscalls_arm64.go
@@ -13,6 +13,7 @@ const (
 var ALLOW_SYSCALLS = []int{
 	// file io
 	syscall.SYS_WRITE, syscall.SYS_CLOSE, syscall.SYS_OPENAT, syscall.SYS_READ, syscall.SYS_LSEEK, syscall.SYS_GETDENTS64,
+	syscall.SYS_FSTAT, syscall.SYS_FCNTL,
 
 	// thread
 	syscall.SYS_FUTEX,


### PR DESCRIPTION
## Summary
- allow the Python sandbox seccomp profile to read the inherited FD 3 payload after sandbox setup
- add the descriptor metadata syscalls used by the Python FD 3 bootstrap on amd64 and arm64

## Why
The Python FD 3 bootstrap introduced a regression where simple code execution could terminate with `signal: bad system call` after seccomp was enabled. This change restores normal execution by permitting the file descriptor operations the bootstrap now relies on.

Closes #250

**This PR is drafted by `gpt-5.4(high)` and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**

## Testing
- validated the updated syscall package compiles with `go test -exec /bin/true ./internal/static/python_syscall`
- verified the change is limited to the Python seccomp allowlists for amd64 and arm64