### PR TITLE
fix: use per-run UIDs for node runner

### DIFF
--- a/internal/core/runner/nodejs/nodejs.go
+++ b/internal/core/runner/nodejs/nodejs.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner"
 	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
+	"github.com/langgenius/dify-sandbox/internal/core/runner/uidpool"
 	"github.com/langgenius/dify-sandbox/internal/static"
 )
 
@@ -46,21 +47,23 @@ func (p *NodeJsRunner) Run(
 ) (chan []byte, chan []byte, chan bool, error) {
 	configuration := static.GetDifySandboxGlobalConfigurations()
 
+	uid, err := uidpool.AcquireUID(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("no available sandbox UID: %w", err)
+	}
+	releaseUID := true
+
 	// capture the output
 	output_handler := runner.NewOutputCaptureRunner()
 	output_handler.SetTimeout(timeout)
 
-	err := p.WithTempDir("/", REQUIRED_FS, func(root_path string) error {
+	err = p.WithTempDir("/", REQUIRED_FS, func(root_path string) error {
 		cleanupRootPath := true
 		defer func() {
 			if cleanupRootPath {
 				os.RemoveAll(root_path)
 			}
 		}()
-
-		output_handler.SetAfterExitHook(func() {
-			os.RemoveAll(root_path)
-		})
 
 		// initialize the environment
 		script_path, err := p.InitializeEnvironment(preload, root_path)
@@ -76,16 +79,11 @@ func (p *NodeJsRunner) Run(
 			codeReader.Close()
 			codeWriter.Close()
 			os.RemoveAll(root_path)
+			uidpool.ReleaseUID(uid)
 		})
 
 		// create a new process
-		cmd := exec.Command(
-			static.GetDifySandboxGlobalConfigurations().NodejsPath,
-			script_path,
-			strconv.Itoa(static.SANDBOX_USER_UID),
-			strconv.Itoa(static.SANDBOX_GROUP_ID),
-			options.Json(),
-		)
+		cmd := exec.Command(configuration.NodejsPath, buildCommandArgs(script_path, uid, options)...)
 		cmd.Env = []string{}
 		cmd.ExtraFiles = []*os.File{codeReader}
 
@@ -110,16 +108,29 @@ func (p *NodeJsRunner) Run(
 			codeWriter.Close()
 			return err
 		}
+		releaseUID = false
 		cleanupRootPath = false
 
 		return nil
 	})
 
 	if err != nil {
+		if releaseUID {
+			uidpool.ReleaseUID(uid)
+		}
 		return nil, nil, nil, err
 	}
 
 	return output_handler.GetStdout(), output_handler.GetStderr(), output_handler.GetDone(), nil
+}
+
+func buildCommandArgs(scriptPath string, uid int, options *types.RunnerOptions) []string {
+	return []string{
+		scriptPath,
+		strconv.Itoa(uid),
+		strconv.Itoa(static.SANDBOX_GROUP_ID),
+		options.Json(),
+	}
 }
 
 func buildBootstrap(preload string) string {

--- a/internal/core/runner/nodejs/nodejs_test.go
+++ b/internal/core/runner/nodejs/nodejs_test.go
@@ -1,8 +1,12 @@
 package nodejs
 
 import (
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
+	"github.com/langgenius/dify-sandbox/internal/static"
 )
 
 func TestBuildBootstrapInjectsPreloadButNotUserCode(t *testing.T) {
@@ -18,5 +22,21 @@ func TestBuildBootstrapInjectsPreloadButNotUserCode(t *testing.T) {
 
 	if strings.Contains(bootstrap, "console.log('user code')") {
 		t.Fatal("bootstrap unexpectedly contains user code")
+	}
+}
+
+func TestBuildCommandArgsUsesProvidedUID(t *testing.T) {
+	args := buildCommandArgs("/tmp/test.js", 10042, &types.RunnerOptions{})
+
+	if args[0] != "/tmp/test.js" {
+		t.Fatalf("expected script path first, got %q", args[0])
+	}
+
+	if args[1] != "10042" {
+		t.Fatalf("expected provided uid, got %q", args[1])
+	}
+
+	if args[1] == strconv.Itoa(static.SANDBOX_USER_UID) {
+		t.Fatal("expected command args to avoid shared sandbox uid")
 	}
 }

--- a/internal/core/runner/python/uid_pool.go
+++ b/internal/core/runner/python/uid_pool.go
@@ -2,85 +2,22 @@ package python
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"log/slog"
-	"os"
-	"sync"
+
+	"github.com/langgenius/dify-sandbox/internal/core/runner/uidpool"
 )
 
-var ErrUIDPoolExhausted = errors.New("sandbox UID pool exhausted")
+var ErrUIDPoolExhausted = uidpool.ErrUIDPoolExhausted
 
-type UIDPool struct {
-	pool chan int
-	min  int
-	max  int
-}
+type UIDPool = uidpool.UIDPool
 
 func NewUIDPool(min, max int) *UIDPool {
-	p := &UIDPool{
-		pool: make(chan int, max-min),
-		min:  min,
-		max:  max,
-	}
-	for i := min; i < max; i++ {
-		p.pool <- i
-	}
-	return p
+	return uidpool.NewUIDPool(min, max)
 }
-
-// Acquire waits for an available UID until ctx is cancelled.
-func (p *UIDPool) Acquire(ctx context.Context) (int, error) {
-	select {
-	case uid := <-p.pool:
-		return uid, nil
-	case <-ctx.Done():
-		return 0, ErrUIDPoolExhausted
-	}
-}
-
-func (p *UIDPool) Release(uid int) {
-	if uid >= p.min && uid < p.max {
-		p.pool <- uid
-	}
-}
-
-func (p *UIDPool) Len() int {
-	return len(p.pool)
-}
-
-// Global singleton
-var (
-	globalPool     *UIDPool
-	globalPoolOnce sync.Once
-)
 
 func AcquireUID(ctx context.Context) (int, error) {
-	globalPoolOnce.Do(func() {
-		globalPool = NewUIDPool(10000, 11000)
-		ensurePasswdEntries(10000, 11000)
-	})
-	return globalPool.Acquire(ctx)
-}
-
-// ensurePasswdEntries appends sandbox UIDs to /etc/passwd so that
-// Python's cleanup (e.g. getpwuid) doesn't trigger blocked syscalls.
-func ensurePasswdEntries(min, max int) {
-	f, err := os.OpenFile("/etc/passwd", os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		slog.Warn("failed to open /etc/passwd for UID entries", "err", err)
-		return
-	}
-	defer f.Close()
-	for i := min; i < max; i++ {
-		fmt.Fprintf(f, "sandbox%d:x:%d:0::/nonexistent:/usr/sbin/nologin\n", i, i)
-	}
-	slog.Info("sandbox UID passwd entries created", "range", fmt.Sprintf("%d-%d", min, max-1))
+	return uidpool.AcquireUID(ctx)
 }
 
 func ReleaseUID(uid int) {
-	globalPoolOnce.Do(func() {
-		globalPool = NewUIDPool(10000, 11000)
-	})
-	globalPool.Release(uid)
+	uidpool.ReleaseUID(uid)
 }

--- a/internal/core/runner/uidpool/uid_pool.go
+++ b/internal/core/runner/uidpool/uid_pool.go
@@ -1,0 +1,85 @@
+package uidpool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+var ErrUIDPoolExhausted = errors.New("sandbox UID pool exhausted")
+
+type UIDPool struct {
+	pool chan int
+	min  int
+	max  int
+}
+
+func NewUIDPool(min, max int) *UIDPool {
+	p := &UIDPool{
+		pool: make(chan int, max-min),
+		min:  min,
+		max:  max,
+	}
+	for i := min; i < max; i++ {
+		p.pool <- i
+	}
+	return p
+}
+
+// Acquire waits for an available UID until ctx is cancelled.
+func (p *UIDPool) Acquire(ctx context.Context) (int, error) {
+	select {
+	case uid := <-p.pool:
+		return uid, nil
+	case <-ctx.Done():
+		return 0, ErrUIDPoolExhausted
+	}
+}
+
+func (p *UIDPool) Release(uid int) {
+	if uid >= p.min && uid < p.max {
+		p.pool <- uid
+	}
+}
+
+func (p *UIDPool) Len() int {
+	return len(p.pool)
+}
+
+var (
+	globalPool     *UIDPool
+	globalPoolOnce sync.Once
+)
+
+func AcquireUID(ctx context.Context) (int, error) {
+	globalPoolOnce.Do(func() {
+		globalPool = NewUIDPool(10000, 11000)
+		ensurePasswdEntries(10000, 11000)
+	})
+	return globalPool.Acquire(ctx)
+}
+
+// ensurePasswdEntries appends sandbox UIDs to /etc/passwd so that
+// Python's cleanup (e.g. getpwuid) doesn't trigger blocked syscalls.
+func ensurePasswdEntries(min, max int) {
+	f, err := os.OpenFile("/etc/passwd", os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		slog.Warn("failed to open /etc/passwd for UID entries", "err", err)
+		return
+	}
+	defer f.Close()
+	for i := min; i < max; i++ {
+		fmt.Fprintf(f, "sandbox%d:x:%d:0::/nonexistent:/usr/sbin/nologin\n", i, i)
+	}
+	slog.Info("sandbox UID passwd entries created", "range", fmt.Sprintf("%d-%d", min, max-1))
+}
+
+func ReleaseUID(uid int) {
+	globalPoolOnce.Do(func() {
+		globalPool = NewUIDPool(10000, 11000)
+	})
+	globalPool.Release(uid)
+}

--- a/internal/core/runner/uidpool/uid_pool_test.go
+++ b/internal/core/runner/uidpool/uid_pool_test.go
@@ -1,4 +1,4 @@
-package python
+package uidpool
 
 import (
 	"context"
@@ -43,7 +43,6 @@ func TestPoolExhaustion(t *testing.T) {
 		acquired = append(acquired, uid)
 	}
 
-	// Pool exhausted: acquire with short timeout should fail
 	timeoutCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 	defer cancel()
 	_, err := pool.Acquire(timeoutCtx)
@@ -51,7 +50,6 @@ func TestPoolExhaustion(t *testing.T) {
 		t.Fatalf("expected ErrUIDPoolExhausted, got %v", err)
 	}
 
-	// Release one, should be able to acquire again
 	pool.Release(acquired[0])
 	uid, err := pool.Acquire(ctx)
 	if err != nil {
@@ -63,18 +61,16 @@ func TestPoolExhaustion(t *testing.T) {
 }
 
 func TestPoolWaitsForRelease(t *testing.T) {
-	pool := NewUIDPool(10000, 10001) // only 1 UID
+	pool := NewUIDPool(10000, 10001)
 	ctx := context.Background()
 
 	uid, _ := pool.Acquire(ctx)
 
-	// Launch a goroutine that releases after 100ms
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		pool.Release(uid)
 	}()
 
-	// Acquire should block and succeed once the UID is released
 	start := time.Now()
 	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
- switch the Node runner from the shared sandbox UID to a per-run UID acquired for each execution
- extract the UID pool into a shared `internal/core/runner/uidpool` package so Node and Python can reuse it without cross-runner init coupling
- release acquired UIDs on startup failure and process exit, and move the UID pool tests to the shared package

## Why
Node still launched sandboxes with the shared `SANDBOX_USER_UID`, unlike Python's per-run isolation model. Moving Node to per-run UIDs keeps the runtimes consistent and strengthens defense-in-depth.

Fixes #252

**This PR is drafted by `gpt-5.4(high)` and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**

## Testing
- `go test ./internal/core/runner/uidpool`
- `go test ./internal/core/runner/nodejs` currently fails in this checkout because the embedded `nodejs.so` asset is missing