### PR TITLE
Fix Python sandbox library path discovery

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -4,51 +4,17 @@
 
 This occurs because the `dify-sandbox` implementation generates a temporary file in the `/var/sandbox/sandbox-python/` directory to save and execute your Python code. Before running your Python code, it uses `syscall.Chroot` to restrict the current process's root to the `/var/sandbox/sandbox-python/` directory. This directory structure, visible to the Python process, determines all the Python modules/packages that can be imported, including modules based on C code.
 
-- Root: `/var/sandbox/sandbox-python/` is the root directory from the Python process perspective. Its subdirectories depend on the `python_lib_path` configuration in your `config.yaml`. Usually, it includes:
+- Root: `/var/sandbox/sandbox-python/` is the root directory from the Python process perspective. Its subdirectories are now discovered automatically from the configured `python_path` before chroot. Usually, it includes:
   - `etc/` directory
   - `python.so` shared object, compiled and built by `dify-sandbox`
   - `usr/lib` directory
   - `usr/local/`
 
-If you haven't configured `python_lib_path`, `dify-sandbox` will default to the following settings (see code [internal/static/config_default_amd64.go](https://github.com/langgenius/dify-sandbox/blob/main/internal/static/config_default_amd64.go); for ARM systems, see `config_default_arm64.go`):
+At startup, `dify-sandbox` runs the configured interpreter from `python_path` and discovers its stdlib, site-packages, and absolute `sys.path` entries. It then appends a small fixed set of system files such as certificate bundles, resolver config, timezone data, and the platform library directory.
 
-```go
-var DEFAULT_PYTHON_LIB_REQUIREMENTS = []string{
-	"/opt/python/lib/python3.14",
-    "/usr/local/lib/python3.14", // Usually your Python installation directory; if using conda, modify this to the conda virtual environment root directory, e.g., /root/anaconda3/envs/{env_name}
-    "/usr/lib/python3.14",
-    "/usr/lib/python3",
-    "/usr/lib/x86_64-linux-gnu/libssl.so.3", // Your Python code's shared object dependency; it will be copied to /var/sandbox/sandbox-python/usr/lib/x86_64-linux-gnu/, and your Python process will load it from /usr/lib/x86_64-linux-gnu/
-    "/usr/lib/x86_64-linux-gnu/libcrypto.so.3", // Similar to above
-    "/etc/ssl/certs/ca-certificates.crt",
-    "/etc/nsswitch.conf",
-    "/etc/hosts",
-    "/etc/resolv.conf",
-    "/run/systemd/resolve/stub-resolv.conf",
-    "/run/resolvconf/resolv.conf",
-}
-```
+`python_lib_path` and `PYTHON_LIB_PATH` are no longer used. If discovery fails, fix `python_path` or the Python installation in your image so that running `python_path -c 'import json'` succeeds before the sandbox starts.
 
-So, when encountering such errors, you need to modify the `python_lib_path` in your `config.yaml` to include the shared object paths required by your Python code. For example:
-```config.yaml
-python_path: /opt/python/bin/python3
-python_lib_path:
-  - "/opt/python/lib/python3.14"
-  - "/usr/local/lib/python3.14"
-  - "/usr/lib/python3.14"
-  - "/usr/lib/python3"
-  - /usr/lib/x86_64-linux-gnu/libssl.so.3
-  - /usr/lib/x86_64-linux-gnu/libcrypto.so.3
-  - /etc/ssl/certs/ca-certificates.crt
-  - /etc/nsswitch.conf
-  - /etc/hosts
-  - /etc/resolv.conf
-  - /run/systemd/resolve/stub-resolv.conf
-  - /run/resolvconf/resolv.conf
-  - *** add path which you required here ***
-```
-
-**Note:** The Go process initializes this environment at startup, so if you configure too many `python_lib_path`, the startup will be very slow. For serverless environments, consider modifying the code to complete this build in a Docker container.
+If you still see missing shared-library errors, install the package or shared object into the same Python environment referenced by `python_path`, or into the system library locations that are already copied into the sandbox. Do not try to work around this by configuring extra sandbox copy paths.
 
 ### 2. My Python code returns an "operation not permitted" error?
 

--- a/cmd/dependencies/init.go
+++ b/cmd/dependencies/init.go
@@ -9,9 +9,13 @@ import (
 )
 
 func main() {
-	static.InitConfig("conf/config.yaml")
+	err := static.InitConfig("conf/config.yaml")
+	if err != nil {
+		slog.Error("failed to initialize config", "err", err)
+		panic(fmt.Sprintf("failed to initialize config: %v", err))
+	}
 
-	err := python.PreparePythonDependenciesEnv()
+	err = python.PreparePythonDependenciesEnv()
 	if err != nil {
 		slog.Error("failed to initialize python dependencies sandbox", "err", err)
 		panic(fmt.Sprintf("failed to initialize python dependencies sandbox: %v", err))

--- a/cmd/test/python/main.go
+++ b/cmd/test/python/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner/python"
 	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
@@ -11,8 +12,14 @@ import (
 )
 
 func main() {
-	static.InitConfig("conf/config.yaml")
-	python.PreparePythonDependenciesEnv()
+	if err := static.InitConfig("conf/config.yaml"); err != nil {
+		slog.Error("failed to initialize config", "err", err)
+		panic(fmt.Sprintf("failed to initialize config: %v", err))
+	}
+	if err := python.PreparePythonDependenciesEnv(); err != nil {
+		slog.Error("failed to initialize python dependencies sandbox", "err", err)
+		panic(fmt.Sprintf("failed to initialize python dependencies sandbox: %v", err))
+	}
 	resp := service.RunPython3Code(context.Background(), `import json;print(json.dumps({"hello": "world"}))`,
 		``,
 		&types.RunnerOptions{

--- a/internal/core/runner/python/env.sh
+++ b/internal/core/runner/python/env.sh
@@ -37,7 +37,7 @@ elif [ -d "$src" ]; then
     mkdir -p "$dest/$src"
 
     # Find all files in the source directory
-    find "$src" -type f,l | while read -r file; do
+    find -L "$src" -type f,l | while read -r file; do
         # Get the relative path of the file
         rel_path="${file#$src/}"
         # Get the directory of the relative path

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -1,6 +1,7 @@
 package static
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"strconv"
@@ -15,19 +16,23 @@ var difySandboxGlobalConfigurations types.DifySandboxGlobalConfigurations
 func InitConfig(path string) error {
 	difySandboxGlobalConfigurations = types.DifySandboxGlobalConfigurations{}
 
-	// read config file
-	configFile, err := os.Open(path)
+	configContent, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
-	defer configFile.Close()
+	var rawConfig map[string]any
+	if err = yaml.Unmarshal(configContent, &rawConfig); err != nil {
+		return err
+	}
 
-	// parse config file
-	decoder := yaml.NewDecoder(configFile)
-	err = decoder.Decode(&difySandboxGlobalConfigurations)
+	err = yaml.Unmarshal(configContent, &difySandboxGlobalConfigurations)
 	if err != nil {
 		return err
+	}
+
+	if _, ok := rawConfig["python_lib_path"]; ok {
+		slog.Warn("python_lib_path is deprecated and ignored; python library paths are discovered from python_path")
 	}
 
 	debug, err := strconv.ParseBool(os.Getenv("DEBUG"))
@@ -69,13 +74,22 @@ func InitConfig(path string) error {
 		difySandboxGlobalConfigurations.PythonPath = "/opt/python/bin/python3"
 	}
 
-	python_lib_path := os.Getenv("PYTHON_LIB_PATH")
-	if python_lib_path != "" {
-		difySandboxGlobalConfigurations.PythonLibPaths = strings.Split(python_lib_path, ",")
+	if os.Getenv("PYTHON_LIB_PATH") != "" {
+		slog.Warn("PYTHON_LIB_PATH is deprecated and ignored; python library paths are discovered from python_path")
 	}
 
-	if len(difySandboxGlobalConfigurations.PythonLibPaths) == 0 {
-		difySandboxGlobalConfigurations.PythonLibPaths = DEFAULT_PYTHON_LIB_REQUIREMENTS
+	// PythonLibPaths is a derived runtime field, not a user-configurable one.
+	// Resolve the interpreter first, then discover its stdlib/site paths here so
+	// downstream sandbox preparation only copies interpreter-owned paths.
+	resolvedPythonPath, err := resolvePythonPath(difySandboxGlobalConfigurations.PythonPath)
+	if err != nil {
+		return fmt.Errorf("resolve python_path %q: %w", difySandboxGlobalConfigurations.PythonPath, err)
+	}
+	difySandboxGlobalConfigurations.PythonPath = resolvedPythonPath
+
+	difySandboxGlobalConfigurations.PythonLibPaths, err = discoverPythonLibPaths(difySandboxGlobalConfigurations.PythonPath)
+	if err != nil {
+		return fmt.Errorf("discover python library paths from %q: %w", difySandboxGlobalConfigurations.PythonPath, err)
 	}
 
 	python_pip_mirror_url := os.Getenv("PIP_MIRROR_URL")

--- a/internal/static/config_default_amd64.go
+++ b/internal/static/config_default_amd64.go
@@ -2,11 +2,7 @@
 
 package static
 
-var DEFAULT_PYTHON_LIB_REQUIREMENTS = []string{
-	"/opt/python/lib/python3.14",
-	"/usr/local/lib/python3.14",
-	"/usr/lib/python3.14",
-	"/usr/lib/python3",
+var DEFAULT_SYSTEM_LIB_REQUIREMENTS = []string{
 	"/usr/lib/x86_64-linux-gnu",
 	"/etc/ssl/certs/ca-certificates.crt",
 	"/etc/nsswitch.conf",

--- a/internal/static/config_default_arm64.go
+++ b/internal/static/config_default_arm64.go
@@ -2,11 +2,7 @@
 
 package static
 
-var DEFAULT_PYTHON_LIB_REQUIREMENTS = []string{
-	"/opt/python/lib/python3.14",
-	"/usr/local/lib/python3.14",
-	"/usr/lib/python3.14",
-	"/usr/lib/python3",
+var DEFAULT_SYSTEM_LIB_REQUIREMENTS = []string{
 	"/usr/lib/aarch64-linux-gnu",
 	"/etc/ssl/certs/ca-certificates.crt",
 	"/etc/nsswitch.conf",

--- a/internal/static/config_test.go
+++ b/internal/static/config_test.go
@@ -1,0 +1,314 @@
+package static
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverPythonLibPathsFindsStdlibAndJSON(t *testing.T) {
+	pythonPath := mustFindTestPython(t)
+
+	paths, err := discoverPythonLibPaths(pythonPath)
+	if err != nil {
+		t.Fatalf("discoverPythonLibPaths returned error: %v", err)
+	}
+
+	if len(paths) == 0 {
+		t.Fatal("expected discovered python library paths")
+	}
+
+	jsonRootFound := false
+	for _, path := range paths {
+		if !filepath.IsAbs(path) {
+			t.Fatalf("expected absolute path, got %q", path)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected existing path %q: %v", path, err)
+		}
+		if strings.HasSuffix(path, ".zip") {
+			jsonRootFound = true
+		}
+		if _, err := os.Stat(filepath.Join(path, "json")); err == nil {
+			jsonRootFound = true
+		}
+		if _, err := os.Stat(filepath.Join(path, "json.py")); err == nil {
+			jsonRootFound = true
+		}
+	}
+
+	if !jsonRootFound {
+		t.Fatal("expected discovered paths to include a json module parent path")
+	}
+}
+
+func TestDiscoverPythonLibPathsIgnoresCurrentWorkingDirectoryShadowing(t *testing.T) {
+	pythonPath := mustFindTestPython(t)
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "json.py"), []byte("raise RuntimeError('shadowed json should not load')\n"), 0o600); err != nil {
+		t.Fatalf("write shadow json: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(originalWD)
+	}()
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+
+	paths, err := discoverPythonLibPaths(pythonPath)
+	if err != nil {
+		t.Fatalf("discoverPythonLibPaths returned error with cwd shadowing: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("expected discovered python library paths")
+	}
+}
+
+func TestInitConfigIgnoresPythonLibPathInputs(t *testing.T) {
+	pythonPath := mustFindTestPython(t)
+	configPath := writeTempConfig(t, "app:\n  port: 8194\npython_path: "+pythonPath+"\npython_lib_path:\n  - /tmp/should-not-be-used-from-yaml\n")
+
+	t.Setenv("PYTHON_PATH", "")
+	t.Setenv("PYTHON_LIB_PATH", "/tmp/should-not-be-used-from-env")
+
+	if err := InitConfig(configPath); err != nil {
+		t.Fatalf("InitConfig returned error: %v", err)
+	}
+
+	config := GetDifySandboxGlobalConfigurations()
+	for _, path := range config.PythonLibPaths {
+		if strings.Contains(path, "should-not-be-used") {
+			t.Fatalf("deprecated python_lib_path input affected final paths: %v", config.PythonLibPaths)
+		}
+	}
+
+	if len(config.PythonLibPaths) == 0 {
+		t.Fatal("expected discovered python library paths")
+	}
+	if !filepath.IsAbs(config.PythonPath) {
+		t.Fatalf("expected resolved absolute python path, got %q", config.PythonPath)
+	}
+}
+
+func TestInitConfigFailsForInvalidPythonPath(t *testing.T) {
+	configPath := writeTempConfig(t, "app:\n  port: 8194\npython_path: /definitely/missing/python\n")
+	t.Setenv("PYTHON_PATH", "")
+
+	err := InitConfig(configPath)
+	if err == nil {
+		t.Fatal("expected InitConfig to fail for invalid python_path")
+	}
+	if !strings.Contains(err.Error(), "python_path") {
+		t.Fatalf("expected error to mention python_path, got %v", err)
+	}
+}
+
+func TestBuildPythonLibPathsFailsWithoutStdlibOrJSONRoot(t *testing.T) {
+	t.Run("missing stdlib", func(t *testing.T) {
+		_, err := buildPythonLibPaths(pythonLibDiscoveryResult{
+			Stdlib:           "/path/does/not/exist",
+			JSONOrigin:       os.Args[0],
+			JSONRelativePath: "json/__init__.py",
+			JSONRoot:         filepath.Dir(os.Args[0]),
+		}, nil)
+		if err == nil || !strings.Contains(err.Error(), "standard library") {
+			t.Fatalf("expected standard library validation error, got %v", err)
+		}
+	})
+
+	t.Run("missing json", func(t *testing.T) {
+		_, err := buildPythonLibPaths(pythonLibDiscoveryResult{
+			Stdlib:           filepath.Dir(os.Args[0]),
+			JSONOrigin:       "/path/does/not/exist/json/__init__.py",
+			JSONRelativePath: "json/__init__.py",
+			JSONRoot:         "/path/does/not/exist",
+		}, nil)
+		if err == nil || !strings.Contains(err.Error(), "json module") {
+			t.Fatalf("expected json validation error, got %v", err)
+		}
+	})
+
+	t.Run("shadowed json outside stdlib", func(t *testing.T) {
+		tempDir := t.TempDir()
+		stdlibPath := filepath.Join(tempDir, "stdlib")
+		shadowedPath := filepath.Join(tempDir, "site-packages")
+		if err := os.MkdirAll(stdlibPath, 0o755); err != nil {
+			t.Fatalf("mkdir stdlib: %v", err)
+		}
+		if err := os.MkdirAll(shadowedPath, 0o755); err != nil {
+			t.Fatalf("mkdir shadowed path: %v", err)
+		}
+
+		_, err := buildPythonLibPaths(pythonLibDiscoveryResult{
+			Stdlib:           stdlibPath,
+			JSONOrigin:       filepath.Join(shadowedPath, "json", "__init__.py"),
+			JSONRelativePath: filepath.Join("json", "__init__.py"),
+			JSONRoot:         shadowedPath,
+			Paths:            []string{stdlibPath, shadowedPath},
+		}, nil)
+		if err == nil || !strings.Contains(err.Error(), "standard library") {
+			t.Fatalf("expected stdlib ownership error, got %v", err)
+		}
+	})
+
+	t.Run("shadowed json under site-packages inside stdlib prefix", func(t *testing.T) {
+		tempDir := t.TempDir()
+		stdlibPath := filepath.Join(tempDir, "python3.12")
+		shadowedPath := filepath.Join(stdlibPath, "site-packages")
+		if err := os.MkdirAll(shadowedPath, 0o755); err != nil {
+			t.Fatalf("mkdir shadowed path: %v", err)
+		}
+
+		_, err := buildPythonLibPaths(pythonLibDiscoveryResult{
+			Stdlib:           stdlibPath,
+			JSONOrigin:       filepath.Join(shadowedPath, "json", "__init__.py"),
+			JSONRelativePath: filepath.Join("site-packages", "json", "__init__.py"),
+			JSONRoot:         stdlibPath,
+			Paths:            []string{stdlibPath, shadowedPath},
+		}, nil)
+		if err == nil || !strings.Contains(err.Error(), "canonical standard-library json location") {
+			t.Fatalf("expected canonical stdlib json location error, got %v", err)
+		}
+	})
+}
+
+func TestBuildPythonLibPathsKeepsLogicalPythonAndSystemPaths(t *testing.T) {
+	tempDir := t.TempDir()
+	realStdlib := filepath.Join(tempDir, "real-stdlib")
+	if err := os.MkdirAll(filepath.Join(realStdlib, "json"), 0o755); err != nil {
+		t.Fatalf("mkdir real stdlib: %v", err)
+	}
+	jsonFile := filepath.Join(realStdlib, "json", "__init__.py")
+	if err := os.WriteFile(jsonFile, []byte("# json"), 0o600); err != nil {
+		t.Fatalf("write json file: %v", err)
+	}
+
+	stdlibSymlink := filepath.Join(tempDir, "stdlib-link")
+	if err := os.Symlink(realStdlib, stdlibSymlink); err != nil {
+		t.Fatalf("symlink stdlib: %v", err)
+	}
+
+	logicalSystemPath := filepath.Join(tempDir, "system-link")
+	if err := os.Symlink(realStdlib, logicalSystemPath); err != nil {
+		t.Fatalf("symlink system path: %v", err)
+	}
+
+	paths, err := buildPythonLibPaths(pythonLibDiscoveryResult{
+		Stdlib:           stdlibSymlink,
+		JSONOrigin:       filepath.Join(stdlibSymlink, "json", "__init__.py"),
+		JSONRelativePath: filepath.Join("json", "__init__.py"),
+		JSONRoot:         stdlibSymlink,
+		Paths:            []string{stdlibSymlink},
+	}, []string{logicalSystemPath})
+	if err != nil {
+		t.Fatalf("buildPythonLibPaths returned error: %v", err)
+	}
+
+	if !containsPath(paths, stdlibSymlink) {
+		t.Fatalf("expected logical stdlib path %q in %v", stdlibSymlink, paths)
+	}
+	if containsPath(paths, realStdlib) {
+		t.Fatalf("did not expect resolved stdlib path %q in %v", realStdlib, paths)
+	}
+	if !containsPath(paths, logicalSystemPath) {
+		t.Fatalf("expected logical system path %q in %v", logicalSystemPath, paths)
+	}
+}
+
+func TestBuildPythonLibPathsAcceptsStdlibZipRoot(t *testing.T) {
+	tempDir := t.TempDir()
+	stdlibPath := filepath.Join(tempDir, "stdlib")
+	if err := os.MkdirAll(stdlibPath, 0o755); err != nil {
+		t.Fatalf("mkdir stdlib: %v", err)
+	}
+	stdlibZipPath := filepath.Join(tempDir, "python312.zip")
+	if err := os.WriteFile(stdlibZipPath, []byte("zip placeholder"), 0o600); err != nil {
+		t.Fatalf("write stdlib zip: %v", err)
+	}
+
+	paths, err := buildPythonLibPaths(pythonLibDiscoveryResult{
+		Stdlib:           stdlibPath,
+		StdlibZipPaths:   []string{stdlibZipPath},
+		JSONOrigin:       stdlibZipPath + "/json/__init__.py",
+		JSONRelativePath: filepath.Join("json", "__init__.py"),
+		JSONRoot:         stdlibZipPath,
+		Paths:            []string{stdlibPath, stdlibZipPath},
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildPythonLibPaths returned error: %v", err)
+	}
+	if !containsPath(paths, stdlibZipPath) {
+		t.Fatalf("expected stdlib zip root %q in %v", stdlibZipPath, paths)
+	}
+}
+
+func TestPythonDiscoveryEnvClearsPythonOverrides(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	t.Setenv("LANG", "C.UTF-8")
+	t.Setenv("PYTHONPATH", "/tmp/injected")
+	t.Setenv("PYTHONHOME", "/tmp/home")
+	t.Setenv("PYTHONUSERBASE", "/tmp/userbase")
+
+	env := pythonDiscoveryEnv()
+	joined := strings.Join(env, "\n")
+
+	if !strings.Contains(joined, "PATH=/usr/bin") {
+		t.Fatalf("expected PATH preserved in %v", env)
+	}
+	for _, clearedVar := range []string{"PYTHONPATH=", "PYTHONHOME=", "PYTHONUSERBASE="} {
+		if !strings.Contains(joined, clearedVar) {
+			t.Fatalf("expected %s in sanitized env %v", clearedVar, env)
+		}
+	}
+	if strings.Contains(joined, "PYTHONPATH=/tmp/injected") || strings.Contains(joined, "PYTHONHOME=/tmp/home") || strings.Contains(joined, "PYTHONUSERBASE=/tmp/userbase") {
+		t.Fatalf("expected python override env vars to be cleared, got %v", env)
+	}
+}
+
+func TestIsCanonicalJSONRelativePath(t *testing.T) {
+	for _, path := range []string{"json.py", "json", filepath.Join("json", "__init__.py"), filepath.Join("json", "decoder.py")} {
+		if !isCanonicalJSONRelativePath(path) {
+			t.Fatalf("expected canonical json path %q", path)
+		}
+	}
+
+	for _, path := range []string{"", filepath.Join("site-packages", "json", "__init__.py"), filepath.Join("dist-packages", "json.py"), filepath.Join("vendor", "json.py"), filepath.Join("nested", "json", "__init__.py")} {
+		if isCanonicalJSONRelativePath(path) {
+			t.Fatalf("expected non-canonical json path %q", path)
+		}
+	}
+}
+
+func mustFindTestPython(t *testing.T) string {
+	t.Helper()
+
+	for _, binary := range []string{"python3", "python"} {
+		path, err := exec.LookPath(binary)
+		if err == nil {
+			return path
+		}
+	}
+
+	t.Skip("python interpreter not available in test environment")
+	return ""
+}
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	return configPath
+}

--- a/internal/static/python_lib_discovery.go
+++ b/internal/static/python_lib_discovery.go
@@ -1,0 +1,367 @@
+package static
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const pythonLibDiscoveryScript = `import json
+import os
+import site
+import sys
+import sysconfig
+
+paths = []
+
+def normalize_existing(path):
+    if path and os.path.isabs(path) and os.path.exists(path):
+        return os.path.normpath(os.path.abspath(path))
+    return ""
+
+def add(path):
+    normalized = normalize_existing(path)
+    if normalized:
+        paths.append(normalized)
+
+def canonical_json_relative_path(root, origin):
+    if not root or not origin:
+        return ""
+    try:
+        relative = os.path.relpath(origin, root)
+    except ValueError:
+        return ""
+    relative = os.path.normpath(relative)
+    if relative in ("json.py", "json") or relative.startswith("json" + os.sep):
+        return relative
+    return ""
+
+stdlib = sysconfig.get_path("stdlib")
+platstdlib = sysconfig.get_path("platstdlib")
+
+for key in ("stdlib", "platstdlib", "purelib", "platlib"):
+    add(sysconfig.get_path(key))
+
+for path in getattr(sys, "path", []):
+    add(path)
+
+try:
+    for path in site.getsitepackages():
+        add(path)
+except Exception:
+    pass
+
+try:
+    add(site.getusersitepackages())
+except Exception:
+    pass
+
+stdlib_roots = []
+for candidate in (stdlib, platstdlib):
+    normalized = normalize_existing(candidate)
+    if normalized:
+        stdlib_roots.append({"raw": normalized, "real": os.path.realpath(candidate)})
+
+stdlib_root_parents = set(root["real"].rsplit(os.sep, 1)[0] for root in stdlib_roots)
+stdlib_zip_paths = []
+for path in getattr(sys, "path", []):
+    raw_path = os.path.abspath(path) if path and os.path.isabs(path) and os.path.exists(path) else ""
+    normalized = normalize_existing(path)
+    real_path = os.path.realpath(path) if normalized else ""
+    if normalized and normalized.endswith(".zip") and real_path.rsplit(os.sep, 1)[0] in stdlib_root_parents:
+        stdlib_zip_paths.append({"raw": raw_path, "real": real_path})
+
+json_origin = getattr(json, "__file__", "") or ""
+json_root = ""
+json_relative_path = ""
+
+if json_origin and os.path.isabs(json_origin):
+    normalized_json_origin = os.path.realpath(json_origin) if os.path.exists(json_origin) else os.path.normpath(json_origin)
+    for candidate in stdlib_roots:
+        for root in (candidate["raw"], candidate["real"]):
+            relative = canonical_json_relative_path(root, normalized_json_origin)
+            if relative:
+                json_root = candidate["raw"]
+                json_relative_path = relative
+                break
+        if json_root:
+            break
+
+    if not json_root:
+        for candidate in stdlib_zip_paths:
+            for root in (candidate["raw"], candidate["real"]):
+                relative = canonical_json_relative_path(root, normalized_json_origin)
+                if relative:
+                    json_root = candidate["raw"]
+                    json_relative_path = relative
+                    break
+            if json_root:
+                break
+
+if json_root:
+    add(json_root)
+
+print(json.dumps({
+    "paths": paths,
+    "stdlib": stdlib,
+    "platstdlib": platstdlib,
+    "stdlib_zip_paths": [candidate["raw"] for candidate in stdlib_zip_paths],
+    "json_origin": json_origin,
+    "json_relative_path": json_relative_path,
+    "json_root": json_root,
+}))
+`
+
+type pythonLibDiscoveryResult struct {
+	Paths            []string `json:"paths"`
+	Stdlib           string   `json:"stdlib"`
+	Platstdlib       string   `json:"platstdlib"`
+	StdlibZipPaths   []string `json:"stdlib_zip_paths"`
+	JSONOrigin       string   `json:"json_origin"`
+	JSONRelativePath string   `json:"json_relative_path"`
+	JSONRoot         string   `json:"json_root"`
+}
+
+// resolvePythonPath validates the configured python_path before discovery runs.
+func resolvePythonPath(pythonPath string) (string, error) {
+	if pythonPath == "" {
+		return "", fmt.Errorf("python_path is empty")
+	}
+
+	if filepath.IsAbs(pythonPath) {
+		info, err := os.Stat(pythonPath)
+		if err != nil {
+			return "", err
+		}
+		if info.IsDir() {
+			return "", fmt.Errorf("path is a directory")
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			return "", fmt.Errorf("path is not executable")
+		}
+		return filepath.Clean(pythonPath), nil
+	}
+
+	resolvedPath, err := exec.LookPath(pythonPath)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err = filepath.Abs(resolvedPath)
+	if err != nil {
+		return "", err
+	}
+
+	return resolvedPath, nil
+}
+
+// discoverPythonLibPaths executes pythonPath before chroot and converts the
+// interpreter's own view of stdlib/site paths into the sandbox copy list.
+//
+// Contract summary for future maintainers:
+//   - discovery runs Python with -P and with Python override env vars cleared,
+//     so results come from pythonPath rather than cwd/PYTHONPATH/PYTHONHOME;
+//   - json must resolve from a canonical standard-library location, not merely
+//     from any importable third-party package named json;
+//   - stdlib zip roots are valid because some Python installations import
+//     modules from python3x.zip;
+//   - Python-discovered paths keep their logical names because the interpreter's
+//     sys.path keeps those names after chroot; the copy script follows directory
+//     symlinks when materializing those logical paths inside the sandbox.
+func discoverPythonLibPaths(pythonPath string) ([]string, error) {
+	command := exec.Command(pythonPath, "-P", "-c", pythonLibDiscoveryScript)
+	command.Env = pythonDiscoveryEnv()
+	output, err := command.CombinedOutput()
+	if err != nil {
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput == "" {
+			return nil, fmt.Errorf("python discovery script failed: %w", err)
+		}
+		return nil, fmt.Errorf("python discovery script failed: %w: %s", err, trimmedOutput)
+	}
+
+	var result pythonLibDiscoveryResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		return nil, fmt.Errorf("parse python discovery output: %w", err)
+	}
+
+	return buildPythonLibPaths(result, DEFAULT_SYSTEM_LIB_REQUIREMENTS)
+}
+
+// buildPythonLibPaths validates interpreter-reported paths and appends fixed
+// system requirements used inside the sandbox.
+//
+// Validation intentionally treats Python and system paths differently:
+//   - Python paths keep their existing logical names, because those are the
+//     names already embedded in the running interpreter's sys.path;
+//   - system paths preserve their logical names (for example /etc/resolv.conf)
+//     so sandboxed code still sees them at the expected in-chroot locations;
+//   - json is accepted only from canonical stdlib-relative locations
+//     (json.py or json/...) under stdlib/platstdlib or an approved stdlib zip.
+func buildPythonLibPaths(result pythonLibDiscoveryResult, systemPaths []string) ([]string, error) {
+	stdlibPath, ok := normalizeExistingAbsolutePath(result.Stdlib)
+	if !ok {
+		return nil, fmt.Errorf("no valid standard library path discovered")
+	}
+
+	allowedJSONRoots := []string{stdlibPath}
+	if platstdlibPath, ok := normalizeExistingAbsolutePath(result.Platstdlib); ok {
+		allowedJSONRoots = append(allowedJSONRoots, platstdlibPath)
+	}
+	for _, zipPath := range result.StdlibZipPaths {
+		if normalizedZipPath, ok := normalizeExistingAbsolutePath(zipPath); ok {
+			allowedJSONRoots = append(allowedJSONRoots, normalizedZipPath)
+		}
+	}
+	allowedJSONRoots = dedupePaths(allowedJSONRoots)
+
+	jsonRootPath, ok := normalizeExistingAbsolutePath(result.JSONRoot)
+	if !ok {
+		return nil, fmt.Errorf("no valid standard-library json module import root discovered from %q", result.JSONOrigin)
+	}
+	if !containsPath(allowedJSONRoots, jsonRootPath) {
+		return nil, fmt.Errorf("json module origin %q is not provided by the interpreter standard library", result.JSONOrigin)
+	}
+	if !isCanonicalJSONRelativePath(result.JSONRelativePath) {
+		return nil, fmt.Errorf("json module origin %q is not in a canonical standard-library json location", result.JSONOrigin)
+	}
+
+	candidates := make([]string, 0, len(allowedJSONRoots)+len(result.Paths)+len(systemPaths))
+	candidates = append(candidates, allowedJSONRoots...)
+	candidates = append(candidates, jsonRootPath)
+	for _, candidate := range result.Paths {
+		normalizedPath, ok := normalizeExistingAbsolutePath(candidate)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, normalizedPath)
+	}
+	for _, candidate := range systemPaths {
+		normalizedPath, ok := normalizeExistingAbsolutePathPreservingSymlinks(candidate)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, normalizedPath)
+	}
+
+	paths := dedupePaths(candidates)
+	if !containsPath(paths, stdlibPath) {
+		return nil, fmt.Errorf("discovered path list is missing standard library path %q", stdlibPath)
+	}
+	if !containsPath(paths, jsonRootPath) {
+		return nil, fmt.Errorf("discovered path list is missing standard-library json import root %q", jsonRootPath)
+	}
+
+	return paths, nil
+}
+
+func dedupePaths(paths []string) []string {
+	result := make([]string, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
+
+	for _, candidate := range paths {
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		result = append(result, candidate)
+	}
+
+	return result
+}
+
+func normalizeExistingAbsolutePath(path string) (string, bool) {
+	return normalizeAbsolutePath(path, false)
+}
+
+func normalizeExistingAbsolutePathPreservingSymlinks(path string) (string, bool) {
+	return normalizeAbsolutePath(path, false)
+}
+
+func normalizeAbsolutePath(path string, resolveSymlinks bool) (string, bool) {
+	if path == "" {
+		return "", false
+	}
+
+	normalizedPath := filepath.Clean(path)
+	if !filepath.IsAbs(normalizedPath) {
+		return "", false
+	}
+
+	if _, err := os.Stat(normalizedPath); err != nil {
+		return "", false
+	}
+	if !resolveSymlinks {
+		return normalizedPath, true
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(normalizedPath)
+	if err != nil {
+		return "", false
+	}
+	if !filepath.IsAbs(resolvedPath) {
+		return "", false
+	}
+
+	return filepath.Clean(resolvedPath), true
+}
+
+func pythonDiscoveryEnv() []string {
+	env := []string{}
+
+	if path := os.Getenv("PATH"); path != "" {
+		env = append(env, "PATH="+path)
+	}
+	if lang := os.Getenv("LANG"); lang != "" {
+		env = append(env, "LANG="+lang)
+	}
+	if lcAll := os.Getenv("LC_ALL"); lcAll != "" {
+		env = append(env, "LC_ALL="+lcAll)
+	}
+	if lcCType := os.Getenv("LC_CTYPE"); lcCType != "" {
+		env = append(env, "LC_CTYPE="+lcCType)
+	}
+	if tmpDir := os.Getenv("TMPDIR"); tmpDir != "" {
+		env = append(env, "TMPDIR="+tmpDir)
+	}
+
+	for _, pythonEnvVar := range []string{
+		"PYTHONHOME",
+		"PYTHONPATH",
+		"PYTHONUSERBASE",
+		"PYTHONSTARTUP",
+		"PYTHONPLATLIBDIR",
+		"PYTHONPYCACHEPREFIX",
+		"PYTHONNOUSERSITE",
+		"PYTHONWARNINGS",
+		"PYTHONCASEOK",
+		"PYTHONUTF8",
+	} {
+		env = append(env, pythonEnvVar+"=")
+	}
+
+	return env
+}
+
+func containsPath(paths []string, path string) bool {
+	for _, candidate := range paths {
+		if candidate == path {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isCanonicalJSONRelativePath(path string) bool {
+	if path == "" {
+		return false
+	}
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "json.py" || cleanPath == "json" {
+		return true
+	}
+	return strings.HasPrefix(cleanPath, "json"+string(os.PathSeparator))
+}

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -6,11 +6,14 @@ type DifySandboxGlobalConfigurations struct {
 		Debug bool   `yaml:"debug"`
 		Key   string `yaml:"key"`
 	} `yaml:"app"`
-	MaxWorkers               int      `yaml:"max_workers"`
-	MaxRequests              int      `yaml:"max_requests"`
-	WorkerTimeout            int      `yaml:"worker_timeout"`
-	PythonPath               string   `yaml:"python_path"`
-	PythonLibPaths           []string `yaml:"python_lib_path"`
+	MaxWorkers    int    `yaml:"max_workers"`
+	MaxRequests   int    `yaml:"max_requests"`
+	WorkerTimeout int    `yaml:"worker_timeout"`
+	PythonPath    string `yaml:"python_path"`
+	// PythonLibPaths is internal-only. InitConfig derives it from PythonPath at
+	// startup, and legacy python_lib_path / PYTHON_LIB_PATH user inputs are
+	// intentionally ignored.
+	PythonLibPaths           []string `yaml:"-"`
 	PythonPipMirrorURL       string   `yaml:"python_pip_mirror_url"`
 	PythonDepsUpdateInterval string   `yaml:"python_deps_update_interval"`
 	NodejsPath               string   `yaml:"nodejs_path"`

--- a/tests/integration_tests/conf/config.yaml
+++ b/tests/integration_tests/conf/config.yaml
@@ -6,22 +6,6 @@ max_workers: 4
 max_requests: 50
 worker_timeout: 30
 python_path: /opt/python/bin/python3
-python_lib_path:
-  - "/opt/python/lib/python3.14"
-  - "/usr/local/lib/python3.14"
-  - "/usr/lib/python3.14"
-  - "/usr/lib/python3"
-  - "/usr/lib/x86_64-linux-gnu"
-  - "/usr/lib/aarch64-linux-gnu"
-  - "/etc/ssl/certs/ca-certificates.crt"
-  - "/etc/nsswitch.conf"
-  - "/etc/hosts"
-  - "/etc/resolv.conf"
-  - "/run/systemd/resolve/stub-resolv.conf"
-  - "/run/resolvconf/resolv.conf"
-  - "/etc/localtime"
-  - "/usr/share/zoneinfo"
-  - "/etc/timezone"
 enable_network: True # please make sure there is no network risk in your environment
 allowed_syscalls: # please leave it empty if you have no idea how seccomp works
 proxy:

--- a/tests/integration_tests/init.go
+++ b/tests/integration_tests/init.go
@@ -9,9 +9,13 @@ import (
 )
 
 func init() {
-	static.InitConfig("conf/config.yaml")
+	err := static.InitConfig("conf/config.yaml")
+	if err != nil {
+		slog.Error("failed to initialize config", "err", err)
+		panic(fmt.Sprintf("failed to initialize config: %v", err))
+	}
 
-	err := python.PreparePythonDependenciesEnv()
+	err = python.PreparePythonDependenciesEnv()
 	if err != nil {
 		slog.Error("failed to initialize python dependencies sandbox", "err", err)
 		panic(fmt.Sprintf("failed to initialize python dependencies sandbox: %v", err))


### PR DESCRIPTION
## Summary
- Fixes #172, fixes #232, fixes #243 by deriving Python sandbox library paths from the configured `python_path` instead of hard-coded Python 3.14 paths.
- Removes user-controlled `python_lib_path` / `PYTHON_LIB_PATH` from the effective config surface and logs deprecation warnings when legacy inputs are present.
- Preserves interpreter-visible logical paths while copying symlinked Python library content into the chroot, so images with `/opt/python` symlink layouts can still import stdlib modules like `json`.

## Tests
- `go test ./internal/static`
- `bash build/build_amd64.sh`
- `docker build --no-cache -t dify-sandbox-dynamic-path-test:local -f docker/amd64-production.gen.dockerfile .`
- Docker build-container verification: started `/main`, called `/v1/sandbox/run`, and verified `import json; print(json.dumps({"hello": "world"}))` returns `{"hello": "world"}` with empty error.

**This PR is drafted by `gpt-5.4(high)` and `gpt-5.5(high)` and I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**