### PR TITLE
fix: separate stderr from execution errors

### DIFF
--- a/internal/core/runner/nodejs/nodejs.go
+++ b/internal/core/runner/nodejs/nodejs.go
@@ -44,12 +44,12 @@ func (p *NodeJsRunner) Run(
 	stdin []byte,
 	preload string,
 	options *types.RunnerOptions,
-) (chan []byte, chan []byte, chan bool, error) {
+) (*runner.OutputCaptureResult, error) {
 	configuration := static.GetDifySandboxGlobalConfigurations()
 
 	uid, err := uidpool.AcquireUID(ctx)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("no available sandbox UID: %w", err)
+		return nil, fmt.Errorf("no available sandbox UID: %w", err)
 	}
 	releaseUID := true
 
@@ -118,10 +118,10 @@ func (p *NodeJsRunner) Run(
 		if releaseUID {
 			uidpool.ReleaseUID(uid)
 		}
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	return output_handler.GetStdout(), output_handler.GetStderr(), output_handler.GetDone(), nil
+	return output_handler.Result(), nil
 }
 
 func buildCommandArgs(scriptPath string, uid int, options *types.RunnerOptions) []string {

--- a/internal/core/runner/output_capture.go
+++ b/internal/core/runner/output_capture.go
@@ -11,10 +11,59 @@ import (
 	"time"
 )
 
+// OutputCaptureResult keeps raw process stderr separate from sandbox-generated
+// execution failures. stderr carries the user/runtime stderr stream exactly as
+// emitted by the process, while execError is reserved for sandbox/runtime
+// failure messages such as timeout, pipe read failure, or wait failure.
+type OutputCaptureResult struct {
+	stdout    chan []byte
+	stderr    chan []byte
+	execError chan []byte
+	done      chan bool
+
+	exitCodeMu sync.RWMutex
+	exitCode   int
+}
+
+func NewOutputCaptureResult() *OutputCaptureResult {
+	return &OutputCaptureResult{
+		stdout:    make(chan []byte),
+		stderr:    make(chan []byte),
+		execError: make(chan []byte),
+		done:      make(chan bool),
+	}
+}
+
+func (r *OutputCaptureResult) GetStdout() chan []byte {
+	return r.stdout
+}
+
+func (r *OutputCaptureResult) GetStderr() chan []byte {
+	return r.stderr
+}
+
+func (r *OutputCaptureResult) GetExecError() chan []byte {
+	return r.execError
+}
+
+func (r *OutputCaptureResult) GetDone() chan bool {
+	return r.done
+}
+
+func (r *OutputCaptureResult) SetExitCode(code int) {
+	r.exitCodeMu.Lock()
+	defer r.exitCodeMu.Unlock()
+	r.exitCode = code
+}
+
+func (r *OutputCaptureResult) GetExitCode() int {
+	r.exitCodeMu.RLock()
+	defer r.exitCodeMu.RUnlock()
+	return r.exitCode
+}
+
 type OutputCaptureRunner struct {
-	stdout chan []byte
-	stderr chan []byte
-	done   chan bool
+	result *OutputCaptureResult
 
 	timeout time.Duration
 
@@ -23,21 +72,25 @@ type OutputCaptureRunner struct {
 
 func NewOutputCaptureRunner() *OutputCaptureRunner {
 	return &OutputCaptureRunner{
-		stdout: make(chan []byte),
-		stderr: make(chan []byte),
-		done:   make(chan bool),
+		result: NewOutputCaptureResult(),
 	}
 }
 
-func (s *OutputCaptureRunner) WriteError(data []byte) {
-	if s.stderr != nil {
-		s.stderr <- data
+func (s *OutputCaptureRunner) WriteExecError(data []byte) {
+	if s.result != nil && s.result.execError != nil {
+		s.result.execError <- data
+	}
+}
+
+func (s *OutputCaptureRunner) WriteStderr(data []byte) {
+	if s.result != nil && s.result.stderr != nil {
+		s.result.stderr <- data
 	}
 }
 
 func (s *OutputCaptureRunner) WriteOutput(data []byte) {
-	if s.stdout != nil {
-		s.stdout <- data
+	if s.result != nil && s.result.stdout != nil {
+		s.result.stdout <- data
 	}
 }
 
@@ -58,8 +111,8 @@ func (s *OutputCaptureRunner) CaptureOutput(ctx context.Context, cmd *exec.Cmd) 
 
 	timer := time.AfterFunc(timeout, func() {
 		if cmd != nil && cmd.Process != nil {
-			// write the error
-			s.WriteError([]byte("error: timeout\n"))
+			s.result.SetExitCode(-1)
+			s.WriteExecError([]byte("error: timeout\n"))
 			// send a signal to the process
 			cmd.Process.Kill()
 		}
@@ -92,8 +145,6 @@ func (s *OutputCaptureRunner) CaptureOutput(ctx context.Context, cmd *exec.Cmd) 
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	written := 0
-
 	// read the output
 	go func() {
 		defer wg.Done()
@@ -106,11 +157,10 @@ func (s *OutputCaptureRunner) CaptureOutput(ctx context.Context, cmd *exec.Cmd) 
 				if err == io.EOF {
 					break
 				} else {
-					s.WriteError([]byte(fmt.Sprintf("error: %v\n", err)))
+					s.WriteExecError([]byte(fmt.Sprintf("error: %v\n", err)))
 					break
 				}
 			}
-			written += n
 			s.WriteOutput(buf[:n])
 		}
 	}()
@@ -127,11 +177,11 @@ func (s *OutputCaptureRunner) CaptureOutput(ctx context.Context, cmd *exec.Cmd) 
 				if err == io.EOF {
 					break
 				} else {
-					s.WriteError([]byte(fmt.Sprintf("error: %v\n", err)))
+					s.WriteExecError([]byte(fmt.Sprintf("error: %v\n", err)))
 					break
 				}
 			}
-			s.WriteError(buf[:n])
+			s.WriteStderr(buf[:n])
 		}
 	}()
 
@@ -145,15 +195,23 @@ func (s *OutputCaptureRunner) CaptureOutput(ctx context.Context, cmd *exec.Cmd) 
 		// wait for the process to finish
 		status, err := cmd.Process.Wait()
 		if err != nil {
-			slog.ErrorContext(ctx, "process finished with error", "status", status.String(), "err", err)
-			s.WriteError([]byte(fmt.Sprintf("error: %v\n", err)))
-		} else if status.ExitCode() != 0 {
-			exitString := status.String()
-			slog.ErrorContext(ctx, "process finished with error", "status", status.String())
-			if strings.Contains(exitString, "bad system call") {
-				s.WriteError([]byte("error: operation not permitted\n"))
-			} else {
-				s.WriteError([]byte(fmt.Sprintf("error: %v\n", exitString)))
+			statusText := ""
+			if status != nil {
+				statusText = status.String()
+			}
+			slog.ErrorContext(ctx, "process finished with error", "status", statusText, "err", err)
+			if s.result.GetExitCode() == 0 {
+				s.result.SetExitCode(-1)
+			}
+			s.WriteExecError([]byte(fmt.Sprintf("error: %v\n", err)))
+		} else if status != nil {
+			s.result.SetExitCode(status.ExitCode())
+			if status.ExitCode() != 0 {
+				exitString := status.String()
+				slog.ErrorContext(ctx, "process finished with error", "status", exitString)
+				if strings.Contains(exitString, "bad system call") {
+					s.WriteExecError([]byte("error: operation not permitted\n"))
+				}
 			}
 		}
 
@@ -161,20 +219,12 @@ func (s *OutputCaptureRunner) CaptureOutput(ctx context.Context, cmd *exec.Cmd) 
 			s.after_exit_hook()
 		}
 
-		s.done <- true
+		s.result.done <- true
 	}()
 
 	return nil
 }
 
-func (s *OutputCaptureRunner) GetStdout() chan []byte {
-	return s.stdout
-}
-
-func (s *OutputCaptureRunner) GetStderr() chan []byte {
-	return s.stderr
-}
-
-func (s *OutputCaptureRunner) GetDone() chan bool {
-	return s.done
+func (s *OutputCaptureRunner) Result() *OutputCaptureResult {
+	return s.result
 }

--- a/internal/core/runner/output_capture_test.go
+++ b/internal/core/runner/output_capture_test.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+type capturedOutput struct {
+	stdout    string
+	stderr    string
+	execError string
+	exitCode  int
+}
+
+func TestCaptureOutputSeparatesStdoutAndStderr(t *testing.T) {
+	r := NewOutputCaptureRunner()
+	cmd := exec.Command("/bin/sh", "-c", "printf 'hello\\n'; printf 'warn\\n' >&2")
+
+	if err := r.CaptureOutput(context.Background(), cmd); err != nil {
+		t.Fatalf("capture output failed: %v", err)
+	}
+
+	output := collectCapturedOutput(r.Result())
+
+	if output.stdout != "hello\n" {
+		t.Fatalf("expected stdout to be captured separately, got %q", output.stdout)
+	}
+
+	if output.stderr != "warn\n" {
+		t.Fatalf("expected stderr to be captured separately, got %q", output.stderr)
+	}
+
+	if output.execError != "" {
+		t.Fatalf("expected no execution error, got %q", output.execError)
+	}
+
+	if output.exitCode != 0 {
+		t.Fatalf("expected zero exit code, got %d", output.exitCode)
+	}
+}
+
+func TestCaptureOutputTracksNonZeroExitCodeWithoutDroppingStderr(t *testing.T) {
+	r := NewOutputCaptureRunner()
+	cmd := exec.Command("/bin/sh", "-c", "printf 'boom\\n' >&2; exit 7")
+
+	if err := r.CaptureOutput(context.Background(), cmd); err != nil {
+		t.Fatalf("capture output failed: %v", err)
+	}
+
+	output := collectCapturedOutput(r.Result())
+
+	if output.stderr != "boom\n" {
+		t.Fatalf("expected stderr to be preserved, got %q", output.stderr)
+	}
+
+	if output.exitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", output.exitCode)
+	}
+
+	if output.execError != "" {
+		t.Fatalf("expected no synthetic exec error for plain non-zero exit, got %q", output.execError)
+	}
+}
+
+func TestCaptureOutputReportsTimeoutAsExecutionError(t *testing.T) {
+	r := NewOutputCaptureRunner()
+	r.SetTimeout(50 * time.Millisecond)
+	cmd := exec.Command("/bin/sh", "-c", "sleep 1")
+
+	if err := r.CaptureOutput(context.Background(), cmd); err != nil {
+		t.Fatalf("capture output failed: %v", err)
+	}
+
+	output := collectCapturedOutput(r.Result())
+
+	if !strings.Contains(output.execError, "error: timeout") {
+		t.Fatalf("expected timeout execution error, got %q", output.execError)
+	}
+
+	if output.exitCode != -1 {
+		t.Fatalf("expected timeout exit code -1, got %d", output.exitCode)
+	}
+}
+
+func collectCapturedOutput(result *OutputCaptureResult) capturedOutput {
+	var output capturedOutput
+
+	for {
+		select {
+		case <-result.GetDone():
+			for {
+				select {
+				case chunk := <-result.GetStdout():
+					output.stdout += string(chunk)
+				case chunk := <-result.GetStderr():
+					output.stderr += string(chunk)
+				case chunk := <-result.GetExecError():
+					output.execError += string(chunk)
+				default:
+					output.exitCode = result.GetExitCode()
+					return output
+				}
+			}
+		case chunk := <-result.GetStdout():
+			output.stdout += string(chunk)
+		case chunk := <-result.GetStderr():
+			output.stderr += string(chunk)
+		case chunk := <-result.GetExecError():
+			output.execError += string(chunk)
+		}
+	}
+}

--- a/internal/core/runner/python/python.go
+++ b/internal/core/runner/python/python.go
@@ -33,25 +33,25 @@ func (p *PythonRunner) Run(
 	stdin []byte,
 	preload string,
 	options *types.RunnerOptions,
-) (chan []byte, chan []byte, chan bool, error) {
+) (*runner.OutputCaptureResult, error) {
 	configuration := static.GetDifySandboxGlobalConfigurations()
 
 	uid, err := AcquireUID(ctx)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("no available sandbox UID: %w", err)
+		return nil, fmt.Errorf("no available sandbox UID: %w", err)
 	}
 
 	bootstrapPath, err := p.InitializeEnvironment(preload, options, uid)
 	if err != nil {
 		ReleaseUID(uid)
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	codeReader, codeWriter, err := os.Pipe()
 	if err != nil {
 		os.Remove(bootstrapPath)
 		ReleaseUID(uid)
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	outputHandler := runner.NewOutputCaptureRunner()
@@ -104,10 +104,10 @@ func (p *PythonRunner) Run(
 		codeWriter.Close()
 		os.Remove(bootstrapPath)
 		ReleaseUID(uid)
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	return outputHandler.GetStdout(), outputHandler.GetStderr(), outputHandler.GetDone(), nil
+	return outputHandler.Result(), nil
 }
 
 func buildBootstrap(preload string, options *types.RunnerOptions, uid int) string {

--- a/internal/service/nodejs.go
+++ b/internal/service/nodejs.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner/nodejs"
@@ -25,42 +24,10 @@ func RunNodeJsCode(ctx context.Context, code string, preload string, options *ru
 	)
 
 	runner := nodejs.NodeJsRunner{}
-	stdout, stderr, done, err := runner.Run(ctx, code, timeout, nil, preload, options)
+	result, err := runner.Run(ctx, code, timeout, nil, preload, options)
 	if err != nil {
 		return types.ErrorResponse(-500, err.Error())
 	}
 
-	var stdoutStr strings.Builder
-	var stderrStr strings.Builder
-
-	defer close(done)
-
-	for {
-		select {
-		case <-done:
-			// Drain any remaining buffered output to avoid races
-		drain:
-			for {
-				select {
-				case out := <-stdout:
-					stdoutStr.Write(out)
-				case err := <-stderr:
-					stderrStr.Write(err)
-				default:
-					break drain
-				}
-			}
-			// Close channels after draining all data
-			close(stdout)
-			close(stderr)
-			return types.SuccessResponse(&RunCodeResponse{
-				Stdout: stdoutStr.String(),
-				Stderr: stderrStr.String(),
-			})
-		case out := <-stdout:
-			stdoutStr.Write(out)
-		case err := <-stderr:
-			stderrStr.Write(err)
-		}
-	}
+	return types.SuccessResponse(collectRunCodeResponse(result))
 }

--- a/internal/service/python.go
+++ b/internal/service/python.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner/python"
@@ -11,11 +10,6 @@ import (
 	"github.com/langgenius/dify-sandbox/internal/static"
 	"github.com/langgenius/dify-sandbox/internal/types"
 )
-
-type RunCodeResponse struct {
-	Stderr string `json:"error"`
-	Stdout string `json:"stdout"`
-}
 
 func RunPython3Code(ctx context.Context, code string, preload string, options *runner_types.RunnerOptions) *types.DifySandboxResponse {
 	if err := checkOptions(options); err != nil {
@@ -31,7 +25,7 @@ func RunPython3Code(ctx context.Context, code string, preload string, options *r
 	)
 
 	runner := python.PythonRunner{}
-	stdout, stderr, done, err := runner.Run(ctx,
+	result, err := runner.Run(ctx,
 		code, timeout, nil, preload, options,
 	)
 	if err != nil {
@@ -41,39 +35,7 @@ func RunPython3Code(ctx context.Context, code string, preload string, options *r
 		return types.ErrorResponse(-500, err.Error())
 	}
 
-	var stdoutStr strings.Builder
-	var stderrStr strings.Builder
-
-	defer close(done)
-
-	for {
-		select {
-		case <-done:
-			// Drain any remaining buffered output to avoid races
-		drain:
-			for {
-				select {
-				case out := <-stdout:
-					stdoutStr.Write(out)
-				case err := <-stderr:
-					stderrStr.Write(err)
-				default:
-					break drain
-				}
-			}
-			// Close channels after draining all data
-			close(stdout)
-			close(stderr)
-			return types.SuccessResponse(&RunCodeResponse{
-				Stdout: stdoutStr.String(),
-				Stderr: stderrStr.String(),
-			})
-		case out := <-stdout:
-			stdoutStr.Write(out)
-		case err := <-stderr:
-			stderrStr.Write(err)
-		}
-	}
+	return types.SuccessResponse(collectRunCodeResponse(result))
 }
 
 type ListDependenciesResponse struct {

--- a/internal/service/run_code.go
+++ b/internal/service/run_code.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+type codeOutputResult interface {
+	GetStdout() chan []byte
+	GetStderr() chan []byte
+	GetExecError() chan []byte
+	GetDone() chan bool
+	GetExitCode() int
+}
+
+// RunCodeResponse is the public /v1/sandbox/run data payload.
+// Stdout is raw process stdout, Stderr is raw process stderr/log output,
+// Error is reserved for actual execution failures, and ExitCode is the
+// process exit status. Successful executions keep Error empty even when
+// Stderr contains logging or other non-fatal stderr output.
+type RunCodeResponse struct {
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	Error    string `json:"error"`
+	ExitCode int    `json:"exit_code"`
+}
+
+func collectRunCodeResponse(result codeOutputResult) *RunCodeResponse {
+	var stdoutStr strings.Builder
+	var stderrStr strings.Builder
+	var execErrorStr strings.Builder
+
+	for {
+		select {
+		case <-result.GetDone():
+			for {
+				select {
+				case out := <-result.GetStdout():
+					stdoutStr.Write(out)
+				case err := <-result.GetStderr():
+					stderrStr.Write(err)
+				case execErr := <-result.GetExecError():
+					execErrorStr.Write(execErr)
+				default:
+					exitCode := result.GetExitCode()
+					stderr := stderrStr.String()
+					return &RunCodeResponse{
+						Stdout:   stdoutStr.String(),
+						Stderr:   stderr,
+						Error:    buildExecutionError(exitCode, stderr, execErrorStr.String()),
+						ExitCode: exitCode,
+					}
+				}
+			}
+		case out := <-result.GetStdout():
+			stdoutStr.Write(out)
+		case err := <-result.GetStderr():
+			stderrStr.Write(err)
+		case execErr := <-result.GetExecError():
+			execErrorStr.Write(execErr)
+		}
+	}
+}
+
+func buildExecutionError(exitCode int, stderr string, execError string) string {
+	if exitCode == 0 {
+		return execError
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("process exited with code %d", exitCode))
+	appendExecutionErrorDetail(&builder, execError)
+	appendExecutionErrorDetail(&builder, stderr)
+
+	return builder.String()
+}
+
+func appendExecutionErrorDetail(builder *strings.Builder, detail string) {
+	if detail == "" {
+		return
+	}
+
+	if builder.Len() > 0 && !strings.HasSuffix(builder.String(), "\n") {
+		builder.WriteByte('\n')
+	}
+
+	builder.WriteString(detail)
+}

--- a/internal/service/run_code_test.go
+++ b/internal/service/run_code_test.go
@@ -1,0 +1,220 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/langgenius/dify-sandbox/internal/types"
+)
+
+type fakeOutputCaptureResult struct {
+	stdout    chan []byte
+	stderr    chan []byte
+	execError chan []byte
+	done      chan bool
+	exitCode  int
+}
+
+func newFakeOutputCaptureResult() *fakeOutputCaptureResult {
+	return &fakeOutputCaptureResult{
+		stdout:    make(chan []byte),
+		stderr:    make(chan []byte),
+		execError: make(chan []byte),
+		done:      make(chan bool),
+	}
+}
+
+func (r *fakeOutputCaptureResult) GetStdout() chan []byte {
+	return r.stdout
+}
+
+func (r *fakeOutputCaptureResult) GetStderr() chan []byte {
+	return r.stderr
+}
+
+func (r *fakeOutputCaptureResult) GetExecError() chan []byte {
+	return r.execError
+}
+
+func (r *fakeOutputCaptureResult) GetDone() chan bool {
+	return r.done
+}
+
+func (r *fakeOutputCaptureResult) GetExitCode() int {
+	return r.exitCode
+}
+
+func TestCollectRunCodeResponseKeepsSuccessfulStderrOutOfError(t *testing.T) {
+	result := newFakeOutputCaptureResult()
+
+	go func() {
+		result.GetStdout() <- []byte("hello\n")
+		result.GetStderr() <- []byte("INFO: log line\n")
+		result.GetDone() <- true
+	}()
+
+	resp := collectRunCodeResponse(result)
+
+	if resp.Stdout != "hello\n" {
+		t.Fatalf("expected stdout to be preserved, got %q", resp.Stdout)
+	}
+
+	if resp.Stderr != "INFO: log line\n" {
+		t.Fatalf("expected stderr to be preserved, got %q", resp.Stderr)
+	}
+
+	if resp.Error != "" {
+		t.Fatalf("expected empty error on successful exit, got %q", resp.Error)
+	}
+
+	if resp.ExitCode != 0 {
+		t.Fatalf("expected zero exit code, got %d", resp.ExitCode)
+	}
+}
+
+func TestCollectRunCodeResponseIncludesExitCodeAndFullStderrOnFailure(t *testing.T) {
+	result := newFakeOutputCaptureResult()
+	result.exitCode = 7
+	stderr := "Traceback (most recent call last):\nValueError: bad input\n"
+
+	go func() {
+		result.GetStdout() <- []byte("partial\n")
+		result.GetStderr() <- []byte(stderr)
+		result.GetDone() <- true
+	}()
+
+	resp := collectRunCodeResponse(result)
+
+	if resp.ExitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", resp.ExitCode)
+	}
+
+	if resp.Stderr != stderr {
+		t.Fatalf("expected full stderr to be preserved, got %q", resp.Stderr)
+	}
+
+	if resp.Stdout != "partial\n" {
+		t.Fatalf("expected stdout to remain raw on failure, got %q", resp.Stdout)
+	}
+
+	if !strings.Contains(resp.Error, "process exited with code 7") {
+		t.Fatalf("expected error to include exit code, got %q", resp.Error)
+	}
+
+	if !strings.Contains(resp.Error, stderr) {
+		t.Fatalf("expected error to include full stderr, got %q", resp.Error)
+	}
+}
+
+func TestCollectRunCodeResponseIncludesExecutionFailureDetails(t *testing.T) {
+	result := newFakeOutputCaptureResult()
+	result.exitCode = -1
+
+	go func() {
+		result.GetExecError() <- []byte("error: timeout\n")
+		result.GetDone() <- true
+	}()
+
+	resp := collectRunCodeResponse(result)
+
+	if resp.Error != "process exited with code -1\nerror: timeout\n" {
+		t.Fatalf("unexpected execution error: %q", resp.Error)
+	}
+
+	if resp.Stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", resp.Stderr)
+	}
+
+	if resp.ExitCode != -1 {
+		t.Fatalf("expected timeout exit code -1, got %d", resp.ExitCode)
+	}
+}
+
+func TestSuccessResponseJSONIncludesStderrAndExitCodeOnSuccess(t *testing.T) {
+	resp := types.SuccessResponse(&RunCodeResponse{
+		Stdout:   "<<RESULT>>ok<<RESULT>>\n",
+		Stderr:   "INFO:root:Starting task...\n",
+		Error:    "",
+		ExitCode: 0,
+	})
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+
+	var payload struct {
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    RunCodeResponse `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload.Code != 0 || payload.Message != "success" {
+		t.Fatalf("expected success envelope, got code=%d message=%q", payload.Code, payload.Message)
+	}
+
+	if payload.Data.Stdout != "<<RESULT>>ok<<RESULT>>\n" {
+		t.Fatalf("expected stdout field in JSON, got %q", payload.Data.Stdout)
+	}
+
+	if payload.Data.Stderr != "INFO:root:Starting task...\n" {
+		t.Fatalf("expected stderr field in JSON, got %q", payload.Data.Stderr)
+	}
+
+	if payload.Data.Error != "" {
+		t.Fatalf("expected empty error field in JSON, got %q", payload.Data.Error)
+	}
+
+	if payload.Data.ExitCode != 0 {
+		t.Fatalf("expected exit_code field in JSON, got %d", payload.Data.ExitCode)
+	}
+}
+
+func TestSuccessResponseJSONKeepsOuterSuccessForExecutionFailure(t *testing.T) {
+	resp := types.SuccessResponse(&RunCodeResponse{
+		Stdout:   "partial output\n",
+		Stderr:   "Traceback (most recent call last):\nValueError: bad input\n",
+		Error:    "process exited with code 1\nTraceback (most recent call last):\nValueError: bad input\n",
+		ExitCode: 1,
+	})
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+
+	var payload struct {
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    RunCodeResponse `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload.Code != 0 || payload.Message != "success" {
+		t.Fatalf("expected outer success envelope for execution failure, got code=%d message=%q", payload.Code, payload.Message)
+	}
+
+	if payload.Data.Stdout != "partial output\n" {
+		t.Fatalf("expected stdout to remain serialized on failure, got %q", payload.Data.Stdout)
+	}
+
+	if payload.Data.ExitCode != 1 {
+		t.Fatalf("expected exit_code=1, got %d", payload.Data.ExitCode)
+	}
+
+	if !strings.Contains(payload.Data.Error, "process exited with code 1") {
+		t.Fatalf("expected serialized error to include exit code, got %q", payload.Data.Error)
+	}
+
+	if !strings.Contains(payload.Data.Error, payload.Data.Stderr) {
+		t.Fatalf("expected serialized error to include full stderr, got %q", payload.Data.Error)
+	}
+}

--- a/tests/integration_tests/nodejs_feature_test.go
+++ b/tests/integration_tests/nodejs_feature_test.go
@@ -100,3 +100,62 @@ console.log(marker);
 		t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
 	}
 }
+
+func TestNodejsConsoleErrorStaysInStderr(t *testing.T) {
+	resp := service.RunNodeJsCode(context.TODO(), `
+console.error("warn from stderr");
+console.log("ok");
+	`, "", &types.RunnerOptions{
+		EnableNetwork: true,
+	})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	data := resp.Data.(*service.RunCodeResponse)
+
+	if !strings.Contains(data.Stdout, "ok") {
+		t.Fatalf("unexpected output: %s\n", data.Stdout)
+	}
+
+	if !strings.Contains(data.Stderr, "warn from stderr") {
+		t.Fatalf("expected console.error output in stderr, got: %s\n", data.Stderr)
+	}
+
+	if data.Error != "" {
+		t.Fatalf("expected empty execution error, got: %s\n", data.Error)
+	}
+
+	if data.ExitCode != 0 {
+		t.Fatalf("expected zero exit code, got: %d\n", data.ExitCode)
+	}
+}
+
+func TestNodejsThrowPopulatesErrorAndStderr(t *testing.T) {
+	resp := service.RunNodeJsCode(context.TODO(), `
+throw new Error("bad input");
+	`, "", &types.RunnerOptions{
+		EnableNetwork: true,
+	})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	data := resp.Data.(*service.RunCodeResponse)
+
+	if !strings.Contains(data.Stderr, "Error: bad input") {
+		t.Fatalf("expected exception in stderr, got: %s\n", data.Stderr)
+	}
+
+	if !strings.Contains(data.Error, "process exited with code") {
+		t.Fatalf("expected error to include exit code, got: %s\n", data.Error)
+	}
+
+	if !strings.Contains(data.Error, data.Stderr) {
+		t.Fatalf("expected error to include full stderr, got: %s\n", data.Error)
+	}
+
+	if data.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit code, got: %d\n", data.ExitCode)
+	}
+}

--- a/tests/integration_tests/nodejs_malicious_test.go
+++ b/tests/integration_tests/nodejs_malicious_test.go
@@ -34,6 +34,10 @@ ls.on( 'close', ( code ) => {
 	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stderr, "operation not permitted") {
 		t.Error(resp.Data.(*service.RunCodeResponse).Stderr)
 	}
+
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+		t.Error(resp.Data.(*service.RunCodeResponse).Error)
+	}
 }
 
 func TestNodejsRunRedeclareFunctionCommand(t *testing.T) {

--- a/tests/integration_tests/nodejs_malicious_test.go
+++ b/tests/integration_tests/nodejs_malicious_test.go
@@ -31,11 +31,11 @@ ls.on( 'close', ( code ) => {
 		t.Error(resp)
 	}
 
-	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stderr, "operation not permitted") {
-		t.Error(resp.Data.(*service.RunCodeResponse).Stderr)
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+		t.Error(resp.Data.(*service.RunCodeResponse).Error)
 	}
 
-	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "operation not permitted") {
 		t.Error(resp.Data.(*service.RunCodeResponse).Error)
 	}
 }

--- a/tests/integration_tests/python_feature_test.go
+++ b/tests/integration_tests/python_feature_test.go
@@ -151,3 +151,65 @@ print(marker)
 		t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
 	}
 }
+
+func TestPythonLoggingStaysInStderr(t *testing.T) {
+	resp := service.RunPython3Code(context.TODO(), `
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logging.info("Starting task...")
+print("ok")
+	`, "", &types.RunnerOptions{
+		EnableNetwork: true,
+	})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	data := resp.Data.(*service.RunCodeResponse)
+
+	if !strings.Contains(data.Stdout, "ok") {
+		t.Fatalf("unexpected output: %s\n", data.Stdout)
+	}
+
+	if !strings.Contains(data.Stderr, "INFO:root:Starting task...") {
+		t.Fatalf("expected logging output in stderr, got: %s\n", data.Stderr)
+	}
+
+	if data.Error != "" {
+		t.Fatalf("expected empty execution error, got: %s\n", data.Error)
+	}
+
+	if data.ExitCode != 0 {
+		t.Fatalf("expected zero exit code, got: %d\n", data.ExitCode)
+	}
+}
+
+func TestPythonExceptionPopulatesErrorAndStderr(t *testing.T) {
+	resp := service.RunPython3Code(context.TODO(), `
+raise ValueError("bad input")
+	`, "", &types.RunnerOptions{
+		EnableNetwork: true,
+	})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	data := resp.Data.(*service.RunCodeResponse)
+
+	if !strings.Contains(data.Stderr, "ValueError: bad input") {
+		t.Fatalf("expected traceback in stderr, got: %s\n", data.Stderr)
+	}
+
+	if !strings.Contains(data.Error, "process exited with code") {
+		t.Fatalf("expected error to include exit code, got: %s\n", data.Error)
+	}
+
+	if !strings.Contains(data.Error, data.Stderr) {
+		t.Fatalf("expected error to include full stderr, got: %s\n", data.Error)
+	}
+
+	if data.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit code, got: %d\n", data.ExitCode)
+	}
+}

--- a/tests/integration_tests/python_malicious_test.go
+++ b/tests/integration_tests/python_malicious_test.go
@@ -40,11 +40,11 @@ os.execl("/bin/ls", "ls")
 		t.Error(resp)
 	}
 
-	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stderr, "operation not permitted") {
-		t.Error(resp.Data.(*service.RunCodeResponse).Stderr)
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+		t.Error(resp.Data.(*service.RunCodeResponse).Error)
 	}
 
-	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "operation not permitted") {
 		t.Error(resp.Data.(*service.RunCodeResponse).Error)
 	}
 }
@@ -61,11 +61,11 @@ subprocess.run(["ls", "-l"])
 		t.Error(resp)
 	}
 
-	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stderr, "operation not permitted") {
-		t.Error(resp.Data.(*service.RunCodeResponse).Stderr)
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+		t.Error(resp.Data.(*service.RunCodeResponse).Error)
 	}
 
-	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "operation not permitted") {
 		t.Error(resp.Data.(*service.RunCodeResponse).Error)
 	}
 }

--- a/tests/integration_tests/python_malicious_test.go
+++ b/tests/integration_tests/python_malicious_test.go
@@ -43,6 +43,10 @@ os.execl("/bin/ls", "ls")
 	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stderr, "operation not permitted") {
 		t.Error(resp.Data.(*service.RunCodeResponse).Stderr)
 	}
+
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+		t.Error(resp.Data.(*service.RunCodeResponse).Error)
+	}
 }
 
 func TestRunCommand(t *testing.T) {
@@ -60,6 +64,10 @@ subprocess.run(["ls", "-l"])
 	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stderr, "operation not permitted") {
 		t.Error(resp.Data.(*service.RunCodeResponse).Stderr)
 	}
+
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, "process exited with code") {
+		t.Error(resp.Data.(*service.RunCodeResponse).Error)
+	}
 }
 
 func TestReadEtcPasswd(t *testing.T) {
@@ -74,5 +82,9 @@ print(open("/etc/passwd").read())
 
 	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stderr, "No such file or directory") {
 		t.Error(resp.Data.(*service.RunCodeResponse).Stderr)
+	}
+
+	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Error, resp.Data.(*service.RunCodeResponse).Stderr) {
+		t.Error(resp.Data.(*service.RunCodeResponse).Error)
 	}
 }


### PR DESCRIPTION
## Summary
- Separate raw process stderr from sandbox-generated execution errors in run responses.
- Add `stderr` and `exit_code` to `/v1/sandbox/run` data while preserving `error` for real execution failures.
- Ensure non-zero exits include both the exit code and full captured stderr in `error`.

## Tests
- `go test "./internal/service/run_code.go" "./internal/service/run_code_test.go"`
- `go test "./internal/core/runner/output_capture.go" "./internal/core/runner/output_capture_test.go"`
- Built Docker image `dify-sandbox-issue255:local`
- Ran container on `58194:8194` and verified `/health`
- Verified Python logging writes to `stderr` with empty `error` and `exit_code: 0`
- Verified Python exception returns non-zero `exit_code` and `error` containing full stderr
- Verified Node.js `console.error` success and thrown exception behavior

Fixes #255

**This PR is drafted by `gpt-5.4` and `gpt-5.5`. I'm responsible for all the changes. I have reviewed the code and varified the behavior, while breaks may still exist. Reach me to fix in this case.**