### PR TITLE
Deny runtime executable memory in sandbox

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -85,3 +85,29 @@ var ALLOW_SYSCALLS = []int{
 If the syscall alias not defined in golang, you can directly use the number instead.
 
 5. Build and Run the whole project again.
+
+### 3. Why are Node.js JIT and WebAssembly unavailable?
+
+Sandboxed Node.js processes always start with V8's `--jitless` option. This is
+part of the memory-execution security boundary: after the trusted bootstrap
+installs seccomp, Node.js and Python may create read/write mappings, but any
+`mmap` or `mprotect` request containing `PROT_EXEC` terminates the sandbox
+process.
+
+Existing native code loaded before seccomp can continue to execute. New `RX`
+and `RWX` mappings, including a staged `RW` to `RX` transition, are denied.
+Native extensions loaded on demand, FFI callbacks, and packages that generate
+machine code at runtime may therefore fail. The trusted Python bootstrap loads
+the native modules required by the sandbox's documented base64, JSON, timezone,
+Requests, and HTTPX features before installing seccomp. Requests and HTTPX are
+loaded only when network access is enabled for that execution.
+
+`ALLOWED_SYSCALLS` cannot override this executable-memory rule and cannot
+enable `pkey_mprotect`, `shmat`, `memfd_create`, `execve`, `execveat`,
+`process_vm_writev`, or `ptrace`.
+
+Without JIT compilation, CPU-intensive JavaScript may run more slowly, and
+WebAssembly and packages that depend on JIT or runtime-generated machine code
+are unsupported. Ordinary interpreted JavaScript, JSON, Buffer, exception
+handling, and network APIs continue to work subject to the existing sandbox
+policies. This behavior cannot be disabled through configuration.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ DifySandbox currently only supports Linux, as it's designed for docker container
 
 If you want to debug the server, firstly use build script to build the sandbox library binaries, then debug as you want with your IDE.
 
+### Node.js runtime compatibility
+
+Every sandboxed Node.js process starts with V8's `--jitless` option as a fixed
+security property. JavaScript therefore runs without JIT compilation,
+WebAssembly is unavailable, and CPU-intensive workloads may run more slowly.
+Basic JavaScript features such as JSON, Buffer, exception handling, and network
+APIs remain available subject to the sandbox's existing policies. There is no
+configuration switch to enable JIT or WebAssembly.
+
+After the trusted runtime bootstrap installs seccomp, `mmap` and `mprotect`
+requests containing `PROT_EXEC` terminate the sandbox process. Existing native
+code loaded before that boundary can still execute, but new `RX`/`RWX` mappings
+and staged `RW` to `RX` transitions are unavailable. Native extensions loaded
+on demand, FFI callbacks, and packages that generate machine code at runtime
+may therefore fail. Native modules needed by the sandbox's documented Python
+features are loaded by the trusted bootstrap before seccomp is installed;
+Requests and HTTPX are loaded only for executions with network access enabled.
 
 ## FAQ
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
 	github.com/seccomp/libseccomp-golang v0.11.0
+	golang.org/x/sys v0.45.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -32,7 +33,6 @@ require (
 	golang.org/x/arch v0.17.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 )

--- a/internal/core/lib/nodejs/add_seccomp.go
+++ b/internal/core/lib/nodejs/add_seccomp.go
@@ -30,7 +30,11 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 	allowed_syscalls = lib.MergeSyscalls(allowed_syscalls, lib.SyscallsFromEnv("ALLOWED_SYSCALLS"))
 	allowed_syscalls = lib.MergeSyscalls(allowed_syscalls, []int{syscall.SYS_SETGROUPS})
 
-	err = lib.Seccomp(allowed_syscalls, allowed_not_kill_syscalls)
+	err = lib.Seccomp(
+		allowed_syscalls,
+		allowed_not_kill_syscalls,
+		[]int{syscall.SYS_MMAP, syscall.SYS_MPROTECT},
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/core/lib/python/add_seccomp.go
+++ b/internal/core/lib/python/add_seccomp.go
@@ -30,7 +30,11 @@ func InitSeccomp(uid int, gid int, enable_network bool) error {
 	allowed_syscalls = lib.MergeSyscalls(allowed_syscalls, lib.SyscallsFromEnv("ALLOWED_SYSCALLS"))
 	allowed_syscalls = lib.MergeSyscalls(allowed_syscalls, []int{syscall.SYS_SETGROUPS})
 
-	err = lib.Seccomp(allowed_syscalls, allowed_not_kill_syscalls)
+	err = lib.Seccomp(
+		allowed_syscalls,
+		allowed_not_kill_syscalls,
+		[]int{syscall.SYS_MMAP, syscall.SYS_MPROTECT},
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/core/lib/seccomp.go
+++ b/internal/core/lib/seccomp.go
@@ -5,18 +5,45 @@ package lib
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"syscall"
 	"unsafe"
 
 	sg "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
 )
 
-func Seccomp(allowed_syscalls []int, allowed_not_kill_syscalls []int) error {
+// These syscalls can create executable mappings or bypass the process boundary.
+// They remain denied even when an operator includes them in ALLOWED_SYSCALLS.
+var nonOverridableDeniedSyscalls = map[int]struct{}{
+	unix.SYS_EXECVE:            {},
+	unix.SYS_EXECVEAT:          {},
+	unix.SYS_MEMFD_CREATE:      {},
+	unix.SYS_PKEY_MPROTECT:     {},
+	unix.SYS_PROCESS_VM_WRITEV: {},
+	unix.SYS_PTRACE:            {},
+	unix.SYS_SHMAT:             {},
+}
+
+type seccompFilter interface {
+	AddRule(sg.ScmpSyscall, sg.ScmpAction) error
+	AddRuleConditional(sg.ScmpSyscall, sg.ScmpAction, []sg.ScmpCondition) error
+	ExportBPF(*os.File) error
+}
+
+type seccompConditionFactory func(uint, sg.ScmpCompareOp, ...uint64) (sg.ScmpCondition, error)
+
+func Seccomp(
+	allowedSyscalls []int,
+	errnoSyscalls []int,
+	execGuardedSyscalls []int,
+) error {
 	ctx, err := sg.NewFilter(sg.ActKillProcess)
 	if err != nil {
 		return err
 	}
+	defer ctx.Release()
 
 	reader, writer, err := os.Pipe()
 	if err != nil {
@@ -25,16 +52,17 @@ func Seccomp(allowed_syscalls []int, allowed_not_kill_syscalls []int) error {
 	defer reader.Close()
 	defer writer.Close()
 
-	for _, syscall := range allowed_syscalls {
-		ctx.AddRule(sg.ScmpSyscall(syscall), sg.ActAllow)
+	err = buildSeccompBPF(
+		ctx,
+		writer,
+		allowedSyscalls,
+		errnoSyscalls,
+		execGuardedSyscalls,
+		sg.MakeCondition,
+	)
+	if err != nil {
+		return err
 	}
-
-	for _, syscall := range allowed_not_kill_syscalls {
-		ctx.AddRule(sg.ScmpSyscall(syscall), sg.ActErrno)
-	}
-
-	file := os.NewFile(uintptr(writer.Fd()), "pipe")
-	ctx.ExportBPF(file)
 
 	// read from pipe
 	data := make([]byte, 4096)
@@ -42,17 +70,18 @@ func Seccomp(allowed_syscalls []int, allowed_not_kill_syscalls []int) error {
 	if err != nil {
 		return err
 	}
+
 	// load bpf
-	sock_filters := make([]syscall.SockFilter, n/8)
-	bytesBuffer := bytes.NewBuffer(data)
-	err = binary.Read(bytesBuffer, binary.LittleEndian, &sock_filters)
+	sockFilters := make([]syscall.SockFilter, n/8)
+	bytesBuffer := bytes.NewBuffer(data[:n])
+	err = binary.Read(bytesBuffer, binary.LittleEndian, &sockFilters)
 	if err != nil {
 		return err
 	}
 
 	bpf := syscall.SockFprog{
-		Len:    uint16(len(sock_filters)),
-		Filter: &sock_filters[0],
+		Len:    uint16(len(sockFilters)),
+		Filter: &sockFilters[0],
 	}
 
 	_, _, err2 := syscall.Syscall(
@@ -64,6 +93,79 @@ func Seccomp(allowed_syscalls []int, allowed_not_kill_syscalls []int) error {
 
 	if err2 != 0 {
 		return err2
+	}
+
+	return nil
+}
+
+func buildSeccompBPF(
+	ctx seccompFilter,
+	output *os.File,
+	allowedSyscalls []int,
+	errnoSyscalls []int,
+	execGuardedSyscalls []int,
+	makeCondition seccompConditionFactory,
+) error {
+	guardedSyscalls := make(map[int]struct{}, len(execGuardedSyscalls))
+	uniqueGuardedSyscalls := make([]int, 0, len(execGuardedSyscalls))
+	for _, syscallNumber := range execGuardedSyscalls {
+		if _, exists := guardedSyscalls[syscallNumber]; exists {
+			continue
+		}
+		guardedSyscalls[syscallNumber] = struct{}{}
+		uniqueGuardedSyscalls = append(uniqueGuardedSyscalls, syscallNumber)
+	}
+
+	for _, syscallNumber := range allowedSyscalls {
+		if _, denied := nonOverridableDeniedSyscalls[syscallNumber]; denied {
+			continue
+		}
+		if _, guarded := guardedSyscalls[syscallNumber]; guarded {
+			continue
+		}
+		if err := ctx.AddRule(sg.ScmpSyscall(syscallNumber), sg.ActAllow); err != nil {
+			return fmt.Errorf("add allow rule for syscall %d: %w", syscallNumber, err)
+		}
+	}
+
+	for _, syscallNumber := range errnoSyscalls {
+		if _, denied := nonOverridableDeniedSyscalls[syscallNumber]; denied {
+			continue
+		}
+		if _, guarded := guardedSyscalls[syscallNumber]; guarded {
+			continue
+		}
+		if err := ctx.AddRule(sg.ScmpSyscall(syscallNumber), sg.ActErrno); err != nil {
+			return fmt.Errorf("add errno rule for syscall %d: %w", syscallNumber, err)
+		}
+	}
+
+	if len(uniqueGuardedSyscalls) > 0 {
+		noExec, err := makeCondition(
+			2,
+			sg.CompareMaskedEqual,
+			uint64(syscall.PROT_EXEC),
+			0,
+		)
+		if err != nil {
+			return fmt.Errorf("create PROT_EXEC seccomp condition: %w", err)
+		}
+
+		for _, syscallNumber := range uniqueGuardedSyscalls {
+			// Any request containing PROT_EXEC falls through to ActKillProcess.
+			if err := ctx.AddRuleConditional(
+				sg.ScmpSyscall(syscallNumber),
+				sg.ActAllow,
+				[]sg.ScmpCondition{noExec},
+			); err != nil {
+				return fmt.Errorf("add no-exec rule for syscall %d: %w", syscallNumber, err)
+			}
+		}
+	}
+
+	err := ctx.ExportBPF(output)
+	if err != nil {
+		return fmt.Errorf("export seccomp BPF: %w", err)
 	}
 
 	return nil

--- a/internal/core/lib/seccomp_test.go
+++ b/internal/core/lib/seccomp_test.go
@@ -1,0 +1,243 @@
+//go:build linux
+
+package lib
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+
+	sg "github.com/seccomp/libseccomp-golang"
+)
+
+type recordedSeccompRule struct {
+	syscall    sg.ScmpSyscall
+	action     sg.ScmpAction
+	conditions []sg.ScmpCondition
+}
+
+type fakeSeccompFilter struct {
+	rules                 []recordedSeccompRule
+	conditionalRules      []recordedSeccompRule
+	addRuleErr            error
+	addRuleConditionalErr error
+	exportErr             error
+	exported              bool
+}
+
+func (f *fakeSeccompFilter) AddRule(call sg.ScmpSyscall, action sg.ScmpAction) error {
+	if f.addRuleErr != nil {
+		return f.addRuleErr
+	}
+	f.rules = append(f.rules, recordedSeccompRule{syscall: call, action: action})
+	return nil
+}
+
+func (f *fakeSeccompFilter) AddRuleConditional(
+	call sg.ScmpSyscall,
+	action sg.ScmpAction,
+	conditions []sg.ScmpCondition,
+) error {
+	if f.addRuleConditionalErr != nil {
+		return f.addRuleConditionalErr
+	}
+	f.conditionalRules = append(f.conditionalRules, recordedSeccompRule{
+		syscall:    call,
+		action:     action,
+		conditions: conditions,
+	})
+	return nil
+}
+
+func (f *fakeSeccompFilter) ExportBPF(_ *os.File) error {
+	if f.exportErr != nil {
+		return f.exportErr
+	}
+	f.exported = true
+	return nil
+}
+
+func makeTestCondition(
+	arg uint,
+	comparison sg.ScmpCompareOp,
+	values ...uint64,
+) (sg.ScmpCondition, error) {
+	condition := sg.ScmpCondition{
+		Argument: arg,
+		Op:       comparison,
+		Operand1: values[0],
+	}
+	if len(values) > 1 {
+		condition.Operand2 = values[1]
+	}
+	return condition, nil
+}
+
+func TestBuildSeccompBPFRejectsExecutableMemory(t *testing.T) {
+	filter := &fakeSeccompFilter{}
+	output, err := os.CreateTemp(t.TempDir(), "seccomp-bpf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer output.Close()
+
+	allowedSyscalls := []int{
+		syscall.SYS_MMAP,
+		syscall.SYS_READ,
+		syscall.SYS_MPROTECT,
+	}
+	errnoSyscalls := []int{syscall.SYS_WRITE}
+	for syscallNumber := range nonOverridableDeniedSyscalls {
+		allowedSyscalls = append(allowedSyscalls, syscallNumber)
+		errnoSyscalls = append(errnoSyscalls, syscallNumber)
+	}
+
+	err = buildSeccompBPF(
+		filter,
+		output,
+		allowedSyscalls,
+		errnoSyscalls,
+		[]int{syscall.SYS_MMAP, syscall.SYS_MPROTECT, syscall.SYS_MMAP},
+		makeTestCondition,
+	)
+	if err != nil {
+		t.Fatalf("buildSeccompBPF() error = %v", err)
+	}
+
+	for _, rule := range filter.rules {
+		if rule.syscall == sg.ScmpSyscall(syscall.SYS_MMAP) ||
+			rule.syscall == sg.ScmpSyscall(syscall.SYS_MPROTECT) {
+			t.Fatalf("guarded syscall %d received an unconditional rule", rule.syscall)
+		}
+	}
+
+	if len(filter.rules) != 2 {
+		t.Fatalf("unconditional rule count = %d, want 2", len(filter.rules))
+	}
+	if filter.rules[0].syscall != sg.ScmpSyscall(syscall.SYS_READ) ||
+		filter.rules[0].action != sg.ActAllow {
+		t.Fatalf("first unconditional rule = %+v, want read/allow", filter.rules[0])
+	}
+	if filter.rules[1].syscall != sg.ScmpSyscall(syscall.SYS_WRITE) ||
+		filter.rules[1].action != sg.ActErrno {
+		t.Fatalf("second unconditional rule = %+v, want write/errno", filter.rules[1])
+	}
+
+	if len(filter.conditionalRules) != 2 {
+		t.Fatalf("conditional rule count = %d, want 2", len(filter.conditionalRules))
+	}
+	for index, rule := range filter.conditionalRules {
+		wantSyscall := syscall.SYS_MMAP
+		if index == 1 {
+			wantSyscall = syscall.SYS_MPROTECT
+		}
+		if rule.syscall != sg.ScmpSyscall(wantSyscall) {
+			t.Fatalf("conditional rule %d syscall = %d, want %d", index, rule.syscall, wantSyscall)
+		}
+		if rule.action != sg.ActAllow {
+			t.Fatalf("conditional rule %d action = %v, want ActAllow", index, rule.action)
+		}
+		if len(rule.conditions) != 1 {
+			t.Fatalf("conditional rule %d condition count = %d, want 1", index, len(rule.conditions))
+		}
+
+		condition := rule.conditions[0]
+		if condition.Argument != 2 {
+			t.Fatalf("conditional rule %d argument = %d, want 2", index, condition.Argument)
+		}
+		if condition.Op != sg.CompareMaskedEqual {
+			t.Fatalf(
+				"conditional rule %d operator = %v, want CompareMaskedEqual",
+				index,
+				condition.Op,
+			)
+		}
+
+		wantMask := uint64(syscall.PROT_EXEC)
+		if condition.Operand1 != wantMask || condition.Operand2 != 0 {
+			t.Fatalf(
+				"conditional rule %d operands = (%d, %d), want (%d, 0)",
+				index,
+				condition.Operand1,
+				condition.Operand2,
+				wantMask,
+			)
+		}
+	}
+
+	if !filter.exported {
+		t.Fatal("expected configured filter to be exported")
+	}
+}
+
+func TestBuildSeccompBPFReturnsConstructionErrors(t *testing.T) {
+	sentinel := errors.New("sentinel")
+
+	tests := []struct {
+		name          string
+		filter        *fakeSeccompFilter
+		allowed       []int
+		errno         []int
+		guarded       []int
+		makeCondition seccompConditionFactory
+	}{
+		{
+			name:          "allow rule",
+			filter:        &fakeSeccompFilter{addRuleErr: sentinel},
+			allowed:       []int{syscall.SYS_READ},
+			makeCondition: makeTestCondition,
+		},
+		{
+			name:          "errno rule",
+			filter:        &fakeSeccompFilter{addRuleErr: sentinel},
+			errno:         []int{syscall.SYS_WRITE},
+			makeCondition: makeTestCondition,
+		},
+		{
+			name:    "no-exec condition",
+			filter:  &fakeSeccompFilter{},
+			guarded: []int{syscall.SYS_MMAP},
+			makeCondition: func(
+				uint,
+				sg.ScmpCompareOp,
+				...uint64,
+			) (sg.ScmpCondition, error) {
+				return sg.ScmpCondition{}, sentinel
+			},
+		},
+		{
+			name:          "conditional rule",
+			filter:        &fakeSeccompFilter{addRuleConditionalErr: sentinel},
+			guarded:       []int{syscall.SYS_MMAP},
+			makeCondition: makeTestCondition,
+		},
+		{
+			name:          "BPF export",
+			filter:        &fakeSeccompFilter{exportErr: sentinel},
+			makeCondition: makeTestCondition,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := os.CreateTemp(t.TempDir(), "seccomp-bpf")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer output.Close()
+
+			err = buildSeccompBPF(
+				test.filter,
+				output,
+				test.allowed,
+				test.errno,
+				test.guarded,
+				test.makeCondition,
+			)
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("buildSeccompBPF() error = %v, want sentinel", err)
+			}
+		})
+	}
+}

--- a/internal/core/runner/nodejs/nodejs.go
+++ b/internal/core/runner/nodejs/nodejs.go
@@ -154,6 +154,7 @@ func (p *NodeJsRunner) Run(
 
 func buildCommandArgs(scriptPath string, uid int, options *types.RunnerOptions) []string {
 	return []string{
+		"--jitless",
 		scriptPath,
 		strconv.Itoa(uid),
 		strconv.Itoa(static.SANDBOX_GROUP_ID),

--- a/internal/core/runner/nodejs/nodejs_test.go
+++ b/internal/core/runner/nodejs/nodejs_test.go
@@ -1,12 +1,10 @@
 package nodejs
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
-	"github.com/langgenius/dify-sandbox/internal/static"
 )
 
 func TestBuildBootstrapInjectsPreloadButNotUserCode(t *testing.T) {
@@ -28,15 +26,15 @@ func TestBuildBootstrapInjectsPreloadButNotUserCode(t *testing.T) {
 func TestBuildCommandArgsUsesProvidedUID(t *testing.T) {
 	args := buildCommandArgs("/tmp/test.js", 10042, &types.RunnerOptions{})
 
-	if args[0] != "/tmp/test.js" {
-		t.Fatalf("expected script path first, got %q", args[0])
+	if args[0] != "--jitless" {
+		t.Fatalf("expected --jitless first, got %q", args[0])
 	}
 
-	if args[1] != "10042" {
-		t.Fatalf("expected provided uid, got %q", args[1])
+	if args[1] != "/tmp/test.js" {
+		t.Fatalf("expected script path second, got %q", args[1])
 	}
 
-	if args[1] == strconv.Itoa(static.SANDBOX_USER_UID) {
-		t.Fatal("expected command args to avoid shared sandbox uid")
+	if args[2] != "10042" {
+		t.Fatalf("expected provided uid, got %q", args[2])
 	}
 }

--- a/internal/core/runner/python/prescript.py
+++ b/internal/core/runner/python/prescript.py
@@ -4,6 +4,31 @@ import sys
 import traceback
 
 
+def _preload_supported_runtime_modules(enable_network):
+    # These supported features load native extension modules. Import them while
+    # the bootstrap is still trusted so later user imports do not need a new
+    # executable mapping after seccomp is installed.
+    import base64
+    import datetime
+    import json
+    import zoneinfo
+
+    if enable_network:
+        try:
+            import httpx
+        except ModuleNotFoundError:
+            pass
+
+        try:
+            import requests
+        except ModuleNotFoundError:
+            pass
+
+
+_preload_supported_runtime_modules(bool({{enable_network}}))
+del _preload_supported_runtime_modules
+
+
 # setup sys.excepthook
 def excepthook(type, value, tb):
     sys.stderr.write("".join(traceback.format_exception(type, value, tb)))

--- a/internal/core/runner/python/python.go
+++ b/internal/core/runner/python/python.go
@@ -137,17 +137,11 @@ func buildBootstrap(preload string, options *types.RunnerOptions, uid int) strin
 		"{{gid}}", strconv.Itoa(static.SANDBOX_GROUP_ID), 1,
 	)
 
+	enableNetwork := "0"
 	if options.EnableNetwork {
-		script = strings.Replace(
-			script,
-			"{{enable_network}}", "1", 1,
-		)
-	} else {
-		script = strings.Replace(
-			script,
-			"{{enable_network}}", "0", 1,
-		)
+		enableNetwork = "1"
 	}
+	script = strings.ReplaceAll(script, "{{enable_network}}", enableNetwork)
 
 	return strings.Replace(
 		script,

--- a/internal/core/runner/python/python_test.go
+++ b/internal/core/runner/python/python_test.go
@@ -21,4 +21,17 @@ func TestBuildBootstrapInjectsPreloadButNotUserCode(t *testing.T) {
 	if strings.Contains(bootstrap, "print('user code')") {
 		t.Fatal("bootstrap unexpectedly contains user code")
 	}
+
+	if strings.Contains(bootstrap, "{{enable_network}}") {
+		t.Fatal("bootstrap contains an unresolved network placeholder")
+	}
+
+	if !strings.Contains(bootstrap, "_preload_supported_runtime_modules(bool(1))") {
+		t.Fatal("expected network runtime modules to be preloaded")
+	}
+
+	networkDisabled := buildBootstrap("", &types.RunnerOptions{}, 123)
+	if !strings.Contains(networkDisabled, "_preload_supported_runtime_modules(bool(0))") {
+		t.Fatal("expected network runtime module preload to be disabled")
+	}
 }

--- a/tests/integration_tests/nodejs_feature_test.go
+++ b/tests/integration_tests/nodejs_feature_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/langgenius/dify-sandbox/internal/service"
 )
 
+func assertNoUnexpectedNodejsStderr(t *testing.T, stderr string) {
+	t.Helper()
+
+	const jitlessWarning = "Warning: disabling flag --expose_wasm due to conflicting flags"
+	trimmed := strings.TrimSpace(stderr)
+	if trimmed != "" && trimmed != jitlessWarning {
+		t.Fatalf("unexpected stderr: %s\n", stderr)
+	}
+}
+
+func assertSuccessfulNodejsExecution(t *testing.T, data *service.RunCodeResponse) {
+	t.Helper()
+
+	if data.ExitCode != 0 || data.Error != "" {
+		t.Fatalf("expected successful Node.js execution, got: %+v", data)
+	}
+}
+
 func TestNodejsBasicTemplate(t *testing.T) {
 	const code = `// declare main function
 function main({a}) {
@@ -33,6 +51,13 @@ console.log(result)`
 		if resp.Code != 0 {
 			t.Fatal(resp)
 		}
+
+		data := resp.Data.(*service.RunCodeResponse)
+		assertSuccessfulNodejsExecution(t, data)
+		assertNoUnexpectedNodejsStderr(t, data.Stderr)
+		if !strings.Contains(data.Stdout, `<<RESULT>>{"b":"a"}<<RESULT>>`) {
+			t.Fatalf("unexpected output: %q", data.Stdout)
+		}
 	})
 }
 
@@ -49,12 +74,12 @@ console.log(Buffer.from(base64, "base64").toString());
 			t.Fatal(resp)
 		}
 
-		if resp.Data.(*service.RunCodeResponse).Stderr != "" {
-			t.Fatalf("unexpected error: %s\n", resp.Data.(*service.RunCodeResponse).Stderr)
-		}
+		data := resp.Data.(*service.RunCodeResponse)
+		assertSuccessfulNodejsExecution(t, data)
+		assertNoUnexpectedNodejsStderr(t, data.Stderr)
 
-		if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stdout, "hello world") {
-			t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
+		if !strings.Contains(data.Stdout, "hello world") {
+			t.Fatalf("unexpected output: %s\n", data.Stdout)
 		}
 	})
 }
@@ -71,12 +96,12 @@ console.log(JSON.stringify({"hello": "world"}));
 			t.Error(resp)
 		}
 
-		if resp.Data.(*service.RunCodeResponse).Stderr != "" {
-			t.Fatalf("unexpected error: %s\n", resp.Data.(*service.RunCodeResponse).Stderr)
-		}
+		data := resp.Data.(*service.RunCodeResponse)
+		assertSuccessfulNodejsExecution(t, data)
+		assertNoUnexpectedNodejsStderr(t, data.Stderr)
 
-		if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stdout, `{"hello":"world"}`) {
-			t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
+		if !strings.Contains(data.Stdout, `{"hello":"world"}`) {
+			t.Fatalf("unexpected output: %s\n", data.Stdout)
 		}
 	})
 }
@@ -92,12 +117,12 @@ console.log(marker);
 		t.Fatal(resp)
 	}
 
-	if resp.Data.(*service.RunCodeResponse).Stderr != "" {
-		t.Fatalf("unexpected error: %s\n", resp.Data.(*service.RunCodeResponse).Stderr)
-	}
+	data := resp.Data.(*service.RunCodeResponse)
+	assertSuccessfulNodejsExecution(t, data)
+	assertNoUnexpectedNodejsStderr(t, data.Stderr)
 
-	if !strings.Contains(resp.Data.(*service.RunCodeResponse).Stdout, "fd3-transport") {
-		t.Fatalf("unexpected output: %s\n", resp.Data.(*service.RunCodeResponse).Stdout)
+	if !strings.Contains(data.Stdout, "fd3-transport") {
+		t.Fatalf("unexpected output: %s\n", data.Stdout)
 	}
 }
 
@@ -159,6 +184,43 @@ throw new Error("bad input");
 		t.Fatalf("expected non-zero exit code, got: %d\n", data.ExitCode)
 	}
 }
+
+func TestNodejsRunsJitless(t *testing.T) {
+	resp := service.RunNodeJsCode(context.TODO(), `
+console.log(JSON.stringify(process.execArgv));
+	`, "", &types.RunnerOptions{})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	data := resp.Data.(*service.RunCodeResponse)
+	if data.ExitCode != 0 || data.Error != "" {
+		t.Fatalf("expected successful Node.js execution, got: %+v", data)
+	}
+	assertNoUnexpectedNodejsStderr(t, data.Stderr)
+	if !strings.Contains(data.Stdout, `"--jitless"`) {
+		t.Fatalf("expected --jitless in process.execArgv, got: %q", data.Stdout)
+	}
+}
+
+func TestNodejsWebAssemblyUnavailable(t *testing.T) {
+	resp := service.RunNodeJsCode(context.TODO(), `
+console.log(typeof WebAssembly);
+	`, "", &types.RunnerOptions{})
+	if resp.Code != 0 {
+		t.Fatal(resp)
+	}
+
+	data := resp.Data.(*service.RunCodeResponse)
+	if data.ExitCode != 0 || data.Error != "" {
+		t.Fatalf("expected successful feature check, got: %+v", data)
+	}
+	assertNoUnexpectedNodejsStderr(t, data.Stderr)
+	if strings.TrimSpace(data.Stdout) != "undefined" {
+		t.Fatalf("expected WebAssembly to be unavailable, got: %q", data.Stdout)
+	}
+}
+
 func TestNodejsNoProxyEnvPropagation(t *testing.T) {
 	resp := service.RunNodeJsCode(context.TODO(), `
 console.log(process.env.NO_PROXY || '');
@@ -170,9 +232,8 @@ console.log(process.env.NO_PROXY || '');
 	}
 
 	data := resp.Data.(*service.RunCodeResponse)
-	if data.Stderr != "" {
-		t.Fatalf("unexpected stderr: %s\n", data.Stderr)
-	}
+	assertSuccessfulNodejsExecution(t, data)
+	assertNoUnexpectedNodejsStderr(t, data.Stderr)
 	if !strings.Contains(data.Stdout, "test.no-proxy.internal") {
 		t.Fatalf("expected NO_PROXY to be propagated to subprocess, got: %q\n", data.Stdout)
 	}
@@ -191,9 +252,8 @@ console.log(process.env.TEST_SANDBOX_ENV_VAR || '');
 	}
 
 	data := resp.Data.(*service.RunCodeResponse)
-	if data.Stderr != "" {
-		t.Fatalf("unexpected stderr: %s\n", data.Stderr)
-	}
+	assertSuccessfulNodejsExecution(t, data)
+	assertNoUnexpectedNodejsStderr(t, data.Stderr)
 	if !strings.Contains(data.Stdout, "hello_from_allowed_env") {
 		t.Fatalf("expected TEST_SANDBOX_ENV_VAR to be propagated to subprocess, got: %q\n", data.Stdout)
 	}
@@ -212,10 +272,9 @@ console.log(process.env.UNLISTED_ENV_VAR || 'not_found');
 	}
 
 	data := resp.Data.(*service.RunCodeResponse)
-	if data.Stderr != "" {
-		t.Fatalf("unexpected stderr: %s\n", data.Stderr)
-	}
-	if strings.Contains(data.Stdout, "should_not_appear") {
-		t.Fatalf("expected UNLISTED_ENV_VAR NOT to be propagated, but it was: %q\n", data.Stdout)
+	assertSuccessfulNodejsExecution(t, data)
+	assertNoUnexpectedNodejsStderr(t, data.Stderr)
+	if strings.TrimSpace(data.Stdout) != "not_found" {
+		t.Fatalf("expected unlisted environment fallback, got: %q\n", data.Stdout)
 	}
 }

--- a/tests/integration_tests/nodejs_malicious_test.go
+++ b/tests/integration_tests/nodejs_malicious_test.go
@@ -2,12 +2,118 @@ package integrationtests_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
 	"github.com/langgenius/dify-sandbox/internal/service"
 )
+
+const nodejsMemoryProtectionScript = `
+const koffi = require("koffi");
+const libc = koffi.load(null);
+const mmap = libc.func("void *mmap(void *, size_t, int, int, int, int64)");
+const mprotect = libc.func("int mprotect(void *, size_t, int)");
+const munmap = libc.func("int munmap(void *, size_t)");
+
+const pageSize = 4096;
+const mapPrivate = 2;
+const mapAnonymous = 0x20;
+const address = mmap(null, pageSize, %d, mapPrivate | mapAnonymous, -1, 0);
+const updatedProtection = %d;
+
+if (updatedProtection >= 0 && mprotect(address, pageSize, updatedProtection) !== 0) {
+	throw new Error("mprotect failed");
+}
+if (munmap(address, pageSize) !== 0) {
+	throw new Error("munmap failed");
+}
+
+console.log("memory-ok");
+`
+
+func TestNodejsMemoryProtectionRejectsExecutableMemory(t *testing.T) {
+	const (
+		protRead  = 1
+		protWrite = 2
+		protExec  = 4
+	)
+
+	tests := []struct {
+		name              string
+		initialProtection int
+		updatedProtection int
+		wantKilled        bool
+	}{
+		{
+			name:              "mmap RW",
+			initialProtection: protRead | protWrite,
+			updatedProtection: -1,
+		},
+		{
+			name:              "mmap RX",
+			initialProtection: protRead | protExec,
+			updatedProtection: -1,
+			wantKilled:        true,
+		},
+		{
+			name:              "mmap RWX",
+			initialProtection: protRead | protWrite | protExec,
+			updatedProtection: -1,
+			wantKilled:        true,
+		},
+		{
+			name:              "mmap RW then mprotect RX",
+			initialProtection: protRead | protWrite,
+			updatedProtection: protRead | protExec,
+			wantKilled:        true,
+		},
+		{
+			name:              "mmap RW then mprotect RWX",
+			initialProtection: protRead | protWrite,
+			updatedProtection: protRead | protWrite | protExec,
+			wantKilled:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp := service.RunNodeJsCode(
+				context.TODO(),
+				fmt.Sprintf(
+					nodejsMemoryProtectionScript,
+					test.initialProtection,
+					test.updatedProtection,
+				),
+				"",
+				&types.RunnerOptions{},
+			)
+			if resp.Code != 0 {
+				t.Fatal(resp)
+			}
+
+			data := resp.Data.(*service.RunCodeResponse)
+			if test.wantKilled {
+				if data.ExitCode == 0 {
+					t.Fatalf("expected seccomp termination, got success: %+v", data)
+				}
+				if !strings.Contains(data.Error, "operation not permitted") {
+					t.Fatalf("expected seccomp error, got: %q", data.Error)
+				}
+				return
+			}
+
+			if data.ExitCode != 0 || data.Error != "" {
+				t.Fatalf("expected successful memory operation, got: %+v", data)
+			}
+			assertNoUnexpectedNodejsStderr(t, data.Stderr)
+			if !strings.Contains(data.Stdout, "memory-ok") {
+				t.Fatalf("unexpected output: %q", data.Stdout)
+			}
+		})
+	}
+}
 
 func TestNodejsRunCommand(t *testing.T) {
 	// Test case for run_command

--- a/tests/integration_tests/python_malicious_test.go
+++ b/tests/integration_tests/python_malicious_test.go
@@ -2,12 +2,148 @@ package integrationtests_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/langgenius/dify-sandbox/internal/core/runner/types"
 	"github.com/langgenius/dify-sandbox/internal/service"
 )
+
+const pythonMemoryProtectionScript = `
+import ctypes
+import os
+
+PROT_READ = 1
+PROT_WRITE = 2
+PROT_EXEC = 4
+MAP_PRIVATE = 2
+MAP_ANONYMOUS = 0x20
+MAP_FAILED = ctypes.c_void_p(-1).value
+PAGE_SIZE = 4096
+
+libc = ctypes.CDLL(None, use_errno=True)
+libc.mmap.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_long,
+]
+libc.mmap.restype = ctypes.c_void_p
+libc.mprotect.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
+libc.mprotect.restype = ctypes.c_int
+libc.munmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+libc.munmap.restype = ctypes.c_int
+
+address = libc.mmap(
+    None,
+    PAGE_SIZE,
+    %d,
+    MAP_PRIVATE | MAP_ANONYMOUS,
+    -1,
+    0,
+)
+if address == MAP_FAILED:
+    errno = ctypes.get_errno()
+    raise OSError(errno, os.strerror(errno))
+
+updated_protection = %d
+if updated_protection >= 0 and libc.mprotect(address, PAGE_SIZE, updated_protection) != 0:
+    errno = ctypes.get_errno()
+    raise OSError(errno, os.strerror(errno))
+
+if libc.munmap(address, PAGE_SIZE) != 0:
+    errno = ctypes.get_errno()
+    raise OSError(errno, os.strerror(errno))
+
+print("memory-ok")
+`
+
+func TestPythonMemoryProtectionRejectsExecutableMemory(t *testing.T) {
+	const (
+		protRead  = 1
+		protWrite = 2
+		protExec  = 4
+	)
+
+	tests := []struct {
+		name              string
+		initialProtection int
+		updatedProtection int
+		wantKilled        bool
+	}{
+		{
+			name:              "mmap RW",
+			initialProtection: protRead | protWrite,
+			updatedProtection: -1,
+		},
+		{
+			name:              "mmap RX",
+			initialProtection: protRead | protExec,
+			updatedProtection: -1,
+			wantKilled:        true,
+		},
+		{
+			name:              "mmap RWX",
+			initialProtection: protRead | protWrite | protExec,
+			updatedProtection: -1,
+			wantKilled:        true,
+		},
+		{
+			name:              "mmap RW then mprotect RX",
+			initialProtection: protRead | protWrite,
+			updatedProtection: protRead | protExec,
+			wantKilled:        true,
+		},
+		{
+			name:              "mmap RW then mprotect RWX",
+			initialProtection: protRead | protWrite,
+			updatedProtection: protRead | protWrite | protExec,
+			wantKilled:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp := service.RunPython3Code(
+				context.TODO(),
+				fmt.Sprintf(
+					pythonMemoryProtectionScript,
+					test.initialProtection,
+					test.updatedProtection,
+				),
+				"",
+				&types.RunnerOptions{},
+			)
+			if resp.Code != 0 {
+				t.Fatal(resp)
+			}
+
+			data := resp.Data.(*service.RunCodeResponse)
+			if test.wantKilled {
+				if data.ExitCode == 0 {
+					t.Fatalf("expected seccomp termination, got success: %+v", data)
+				}
+				if !strings.Contains(data.Error, "operation not permitted") {
+					t.Fatalf("expected seccomp error, got: %q", data.Error)
+				}
+				return
+			}
+
+			if data.ExitCode != 0 {
+				t.Fatalf("expected successful memory operation, got: %+v", data)
+			}
+			if data.Stderr != "" || data.Error != "" {
+				t.Fatalf("unexpected execution error: %+v", data)
+			}
+			if !strings.Contains(data.Stdout, "memory-ok") {
+				t.Fatalf("unexpected output: %q", data.Stdout)
+			}
+		})
+	}
+}
 
 func TestSysFork(t *testing.T) {
 	// Test case for sys_fork


### PR DESCRIPTION
## Summary

- Reject `mmap` and `mprotect` requests containing `PROT_EXEC` in Python and Node.js sandboxes.
- Run Node.js with `--jitless` and keep equivalent code-execution syscalls non-overridable.
- Preload supported Python native modules before seccomp, with regression coverage and compatibility documentation.

## Why

The previous seccomp allowlist permitted executable mappings, including staged RW-to-RX transitions. User code could therefore generate and execute native machine code after the sandbox boundary was installed.

## Impact

- Read/write mappings and ordinary Python and Node.js workflows remain available.
- New RX/RWX mappings and RW-to-RX transitions are denied.
- Node.js JIT and WebAssembly are unavailable.
- Lazy native extensions, FFI callbacks, and packages that require runtime-generated machine code may fail.
- Request preload behavior is unchanged.

## Validation

- `bash build/build_amd64.sh`
- `go test ./internal/core/lib`
- `go test ./internal/static/...`
- Python and Node.js runner unit tests in the official test image
- Full amd64 Docker integration suite
- Ordinary-code regressions: 11 Python tests and 9 Node.js tests
- `go vet ./internal/core/lib ./internal/static/...`
- `git diff --check`

Arm64 execution remains covered by CI.

**This PR is made with gpt-5.6-sol (codex), while I'm responsible for all the changes.
**