### PR TITLE
feat: allow disabling periodic Python dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ DifySandbox currently only supports Linux, as it's designed for docker container
 
 If you want to debug the server, firstly use build script to build the sandbox library binaries, then debug as you want with your IDE.
 
+### Dependency synchronization
+
+Python dependencies are synchronized into the sandbox once at startup. By default, the sandbox also refreshes them every 30 minutes. Configure `python_deps_update_interval` in `conf/config.yaml` (or `PYTHON_DEPS_UPDATE_INTERVAL`) to change the interval. To disable only the periodic refresh, set `enable_python_deps_periodic_update` to `False` (or set `ENABLE_PYTHON_DEPS_PERIODIC_UPDATE=false`); startup initialization and the manual dependency APIs remain available.
+
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to debug the server, firstly use build script to build the sandbox l
 
 ### Dependency synchronization
 
-Python dependencies are synchronized into the sandbox once at startup. By default, the sandbox also refreshes them every 30 minutes. Configure `python_deps_update_interval` in `conf/config.yaml` (or `PYTHON_DEPS_UPDATE_INTERVAL`) to change the interval. To disable only the periodic refresh, set `enable_python_deps_periodic_update` to `False` (or set `ENABLE_PYTHON_DEPS_PERIODIC_UPDATE=false`); startup initialization and the manual dependency APIs remain available.
+Python dependencies are synchronized into the sandbox once at startup. By default, the sandbox also refreshes them every 30 minutes. Configure `python_deps_update_interval` in `conf/config.yaml` (or `PYTHON_DEPS_UPDATE_INTERVAL`) to change the interval. To disable only the periodic refresh, set `enable_python_deps_periodic_update` to `false` (or set `ENABLE_PYTHON_DEPS_PERIODIC_UPDATE=false`); startup initialization and the manual dependency APIs remain available.
 
 
 ## FAQ

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -6,8 +6,6 @@ max_workers: 4
 max_requests: 50
 worker_timeout: 5
 python_path: /opt/python/bin/python3
-python_deps_update_interval: 30m
-enable_python_deps_periodic_update: True # set to False to avoid periodic dependency rescans
 enable_network: True # please make sure there is no network risk in your environment
 enable_preload: False # please keep it as False for security purposes
 log_path: "./logs" # path to store log files, default is "./logs"

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -6,6 +6,8 @@ max_workers: 4
 max_requests: 50
 worker_timeout: 5
 python_path: /opt/python/bin/python3
+python_deps_update_interval: 30m
+enable_python_deps_periodic_update: True # set to False to avoid periodic dependency rescans
 enable_network: True # please make sure there is no network risk in your environment
 enable_preload: False # please keep it as False for security purposes
 log_path: "./logs" # path to store log files, default is "./logs"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/langgenius/dify-sandbox/internal/controller"
 	"github.com/langgenius/dify-sandbox/internal/core/runner/python"
 	"github.com/langgenius/dify-sandbox/internal/static"
+	"github.com/langgenius/dify-sandbox/internal/types"
 	"github.com/langgenius/dify-sandbox/internal/utils/log"
 )
 
@@ -74,22 +75,45 @@ func initDependencies() {
 	}
 	slog.Info("python dependencies sandbox initialized")
 
-	// start a ticker to update python dependencies to keep the sandbox up-to-date
-	go func() {
-		updateInterval := static.GetDifySandboxGlobalConfigurations().PythonDepsUpdateInterval
-		tickerDuration, err := time.ParseDuration(updateInterval)
-		if err != nil {
-			slog.Error("failed to parse python dependencies update interval, skip periodic updates", "err", err)
-			return
+	go startPythonDependenciesUpdater(dependencies)
+}
+
+func startPythonDependenciesUpdater(dependencies static.RunnerDependencies) {
+	config := static.GetDifySandboxGlobalConfigurations()
+
+	updateInterval, enabled, err := pythonDependenciesUpdateInterval(config)
+	if err != nil {
+		slog.Error("invalid python dependencies periodic update configuration, skip periodic updates", "err", err)
+		return
+	}
+	if !enabled {
+		slog.Info("python dependencies periodic updates are disabled")
+		return
+	}
+
+	ticker := time.NewTicker(updateInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := updatePythonDependencies(dependencies); err != nil {
+			slog.Error("failed to update Python dependencies", "err", err)
 		}
-		ticker := time.NewTicker(tickerDuration)
-		defer ticker.Stop()
-		for range ticker.C {
-			if err := updatePythonDependencies(dependencies); err != nil {
-				slog.Error("Failed to update Python dependencies", "err", err)
-			}
-		}
-	}()
+	}
+}
+
+func pythonDependenciesUpdateInterval(config types.DifySandboxGlobalConfigurations) (time.Duration, bool, error) {
+	if !config.EnablePythonDepsPeriodicUpdate {
+		return 0, false, nil
+	}
+
+	updateInterval, err := time.ParseDuration(config.PythonDepsUpdateInterval)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse python dependencies update interval: %w", err)
+	}
+	if updateInterval <= 0 {
+		return 0, false, fmt.Errorf("python dependencies update interval must be greater than 0")
+	}
+
+	return updateInterval, true, nil
 }
 
 func updatePythonDependencies(dependencies static.RunnerDependencies) error {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/langgenius/dify-sandbox/internal/types"
+)
+
+func TestPythonDependenciesUpdateInterval(t *testing.T) {
+	tests := []struct {
+		name           string
+		enabled        bool
+		interval       string
+		wantDuration   time.Duration
+		wantEnabled    bool
+		wantErr        bool
+		wantErrContent string
+	}{
+		{
+			name:        "disabled",
+			enabled:     false,
+			interval:    "not-a-duration",
+			wantEnabled: false,
+		},
+		{
+			name:           "invalid interval",
+			enabled:        true,
+			interval:       "not-a-duration",
+			wantErr:        true,
+			wantErrContent: "parse python dependencies update interval",
+		},
+		{
+			name:           "zero interval",
+			enabled:        true,
+			interval:       "0",
+			wantErr:        true,
+			wantErrContent: "must be greater than 0",
+		},
+		{
+			name:         "valid interval",
+			enabled:      true,
+			interval:     "30m",
+			wantDuration: 30 * time.Minute,
+			wantEnabled:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := types.DifySandboxGlobalConfigurations{
+				EnablePythonDepsPeriodicUpdate: tt.enabled,
+				PythonDepsUpdateInterval:       tt.interval,
+			}
+
+			duration, enabled, err := pythonDependenciesUpdateInterval(config)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContent) {
+					t.Fatalf("expected error to contain %q, got %q", tt.wantErrContent, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if enabled != tt.wantEnabled {
+				t.Fatalf("expected enabled=%v, got %v", tt.wantEnabled, enabled)
+			}
+			if duration != tt.wantDuration {
+				t.Fatalf("expected duration %v, got %v", tt.wantDuration, duration)
+			}
+		})
+	}
+}

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -14,7 +14,11 @@ import (
 var difySandboxGlobalConfigurations types.DifySandboxGlobalConfigurations
 
 func InitConfig(path string) error {
-	difySandboxGlobalConfigurations = types.DifySandboxGlobalConfigurations{}
+	// Preserve the historical behavior unless YAML or the environment explicitly
+	// disables the background updater.
+	difySandboxGlobalConfigurations = types.DifySandboxGlobalConfigurations{
+		EnablePythonDepsPeriodicUpdate: true,
+	}
 
 	configContent, err := os.ReadFile(path)
 	if err != nil {
@@ -118,11 +122,6 @@ func InitConfig(path string) error {
 		difySandboxGlobalConfigurations.PythonDepsUpdateInterval = "30m"
 	}
 
-	// Keep periodic updates enabled for existing deployments unless the option is
-	// explicitly set to false in YAML or the environment.
-	if _, ok := rawConfig["enable_python_deps_periodic_update"]; !ok {
-		difySandboxGlobalConfigurations.EnablePythonDepsPeriodicUpdate = true
-	}
 	if enablePeriodicUpdates := os.Getenv("ENABLE_PYTHON_DEPS_PERIODIC_UPDATE"); enablePeriodicUpdates != "" {
 		parsed, err := strconv.ParseBool(enablePeriodicUpdates)
 		if err != nil {

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -118,6 +118,19 @@ func InitConfig(path string) error {
 		difySandboxGlobalConfigurations.PythonDepsUpdateInterval = "30m"
 	}
 
+	// Keep periodic updates enabled for existing deployments unless the option is
+	// explicitly set to false in YAML or the environment.
+	if _, ok := rawConfig["enable_python_deps_periodic_update"]; !ok {
+		difySandboxGlobalConfigurations.EnablePythonDepsPeriodicUpdate = true
+	}
+	if enablePeriodicUpdates := os.Getenv("ENABLE_PYTHON_DEPS_PERIODIC_UPDATE"); enablePeriodicUpdates != "" {
+		parsed, err := strconv.ParseBool(enablePeriodicUpdates)
+		if err != nil {
+			return fmt.Errorf("parse ENABLE_PYTHON_DEPS_PERIODIC_UPDATE: %w", err)
+		}
+		difySandboxGlobalConfigurations.EnablePythonDepsPeriodicUpdate = parsed
+	}
+
 	nodejs_path := os.Getenv("NODEJS_PATH")
 	if nodejs_path != "" {
 		difySandboxGlobalConfigurations.NodejsPath = nodejs_path

--- a/internal/static/config_test.go
+++ b/internal/static/config_test.go
@@ -98,6 +98,69 @@ func TestInitConfigIgnoresPythonLibPathInputs(t *testing.T) {
 	}
 }
 
+func TestInitConfigDefaultsToPythonDepsPeriodicUpdates(t *testing.T) {
+	pythonPath := mustFindTestPython(t)
+	configPath := writeTempConfig(t, "app:\n  port: 8194\npython_path: "+pythonPath+"\n")
+
+	t.Setenv("PYTHON_DEPS_UPDATE_INTERVAL", "")
+	t.Setenv("ENABLE_PYTHON_DEPS_PERIODIC_UPDATE", "")
+
+	if err := InitConfig(configPath); err != nil {
+		t.Fatalf("InitConfig returned error: %v", err)
+	}
+
+	config := GetDifySandboxGlobalConfigurations()
+	if !config.EnablePythonDepsPeriodicUpdate {
+		t.Fatal("expected periodic Python dependency updates to be enabled by default")
+	}
+	if config.PythonDepsUpdateInterval != "30m" {
+		t.Fatalf("expected default update interval 30m, got %q", config.PythonDepsUpdateInterval)
+	}
+}
+
+func TestInitConfigCanDisablePythonDepsPeriodicUpdates(t *testing.T) {
+	pythonPath := mustFindTestPython(t)
+
+	t.Run("yaml", func(t *testing.T) {
+		configPath := writeTempConfig(t, "app:\n  port: 8194\npython_path: "+pythonPath+"\nenable_python_deps_periodic_update: false\n")
+		t.Setenv("ENABLE_PYTHON_DEPS_PERIODIC_UPDATE", "")
+
+		if err := InitConfig(configPath); err != nil {
+			t.Fatalf("InitConfig returned error: %v", err)
+		}
+		if GetDifySandboxGlobalConfigurations().EnablePythonDepsPeriodicUpdate {
+			t.Fatal("expected periodic Python dependency updates to be disabled")
+		}
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		configPath := writeTempConfig(t, "app:\n  port: 8194\npython_path: "+pythonPath+"\nenable_python_deps_periodic_update: true\n")
+		t.Setenv("ENABLE_PYTHON_DEPS_PERIODIC_UPDATE", "false")
+
+		if err := InitConfig(configPath); err != nil {
+			t.Fatalf("InitConfig returned error: %v", err)
+		}
+		if GetDifySandboxGlobalConfigurations().EnablePythonDepsPeriodicUpdate {
+			t.Fatal("expected environment setting to disable periodic Python dependency updates")
+		}
+	})
+}
+
+func TestInitConfigFailsForInvalidPythonDepsPeriodicUpdatesEnv(t *testing.T) {
+	pythonPath := mustFindTestPython(t)
+	configPath := writeTempConfig(t, "app:\n  port: 8194\npython_path: "+pythonPath+"\n")
+
+	t.Setenv("ENABLE_PYTHON_DEPS_PERIODIC_UPDATE", "not-a-bool")
+
+	err := InitConfig(configPath)
+	if err == nil {
+		t.Fatal("expected InitConfig to fail for invalid ENABLE_PYTHON_DEPS_PERIODIC_UPDATE")
+	}
+	if !strings.Contains(err.Error(), "ENABLE_PYTHON_DEPS_PERIODIC_UPDATE") {
+		t.Fatalf("expected error to mention ENABLE_PYTHON_DEPS_PERIODIC_UPDATE, got %v", err)
+	}
+}
+
 func TestInitConfigFailsForInvalidPythonPath(t *testing.T) {
 	configPath := writeTempConfig(t, "app:\n  port: 8194\npython_path: /definitely/missing/python\n")
 	t.Setenv("PYTHON_PATH", "")

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -16,12 +16,15 @@ type DifySandboxGlobalConfigurations struct {
 	PythonLibPaths           []string `yaml:"-"`
 	PythonPipMirrorURL       string   `yaml:"python_pip_mirror_url"`
 	PythonDepsUpdateInterval string   `yaml:"python_deps_update_interval"`
-	NodejsPath               string   `yaml:"nodejs_path"`
-	EnableNetwork            bool     `yaml:"enable_network"`
-	EnablePreload            bool     `yaml:"enable_preload"`
-	AllowedSyscalls          []int    `yaml:"allowed_syscalls"`
-	LogPath                  string   `yaml:"log_path"`
-	Proxy                    struct {
+	// EnablePythonDepsPeriodicUpdate controls only the background updater;
+	// startup initialization and explicit dependency refresh APIs stay enabled.
+	EnablePythonDepsPeriodicUpdate bool   `yaml:"enable_python_deps_periodic_update"`
+	NodejsPath                     string `yaml:"nodejs_path"`
+	EnableNetwork                  bool   `yaml:"enable_network"`
+	EnablePreload                  bool   `yaml:"enable_preload"`
+	AllowedSyscalls                []int  `yaml:"allowed_syscalls"`
+	LogPath                        string `yaml:"log_path"`
+	Proxy                          struct {
 		Socks5  string `yaml:"socks5"`
 		Https   string `yaml:"https"`
 		Http    string `yaml:"http"`


### PR DESCRIPTION
## Summary

- Add `enable_python_deps_periodic_update` / `ENABLE_PYTHON_DEPS_PERIODIC_UPDATE` to control the background Python dependency updater independently of startup initialization and manual dependency APIs.
- Default the new option to `true` to preserve existing behavior.
- Validate configured update intervals and reject non-positive values before creating a ticker.
- Document dependency synchronization behavior.

## Tests

- `gofmt` on changed Go files
- Linux/arm64 container: `go test ./internal/server ./internal/static`
- `git diff --check`

Fixes #169
