### PR TITLE
build(deps): bump golang.org/x/crypto to v0.56.0 (CVE-2026-78662, CVE-2026-56855)

### DIFF
--- a/docker/templates/test.dockerfile
+++ b/docker/templates/test.dockerfile
@@ -1,5 +1,5 @@
 # Test environment Dockerfile template
-ARG GOLANG_VERSION=1.25.0
+ARG GOLANG_VERSION=1.26.8
 ARG PYTHON_VERSION=docker.io/langgenius/python:3-debian13-sfw-ent-dev
 ARG DEBIAN_MIRROR="http://deb.debian.org/debian testing main"
 ARG PYTHON_PACKAGES="httpx==0.27.2 requests==2.33.0 jinja2==3.1.6 PySocks httpx[socks]"

--- a/docker/versions.yaml
+++ b/docker/versions.yaml
@@ -2,7 +2,7 @@
 versions:
   # Base images
   python: "dhi.io/python:3-debian13-sfw-ent-dev"
-  golang: "1.25.0"
+  golang: "1.26.8"
   nodejs: "v20.20.0"
   
   # Python packages (unified configuration)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/langgenius/dify-sandbox
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/gin-gonic/gin v1.10.0
@@ -30,7 +30,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.17.0 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 golang.org/x/arch v0.17.0 h1:4O3dfLzd+lQewptAHqjewQZQDyEdejz3VwgeYwkZneU=
 golang.org/x/arch v0.17.0/go.mod h1:bdwinDaKcfZUGpH09BB7ZmOfhalA8lQdzl62l8gGWsk=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
## Summary

Image scans report two high-severity vulnerabilities in `golang.org/x/crypto` v0.55.0, both fixed in v0.56.0:

| CVE | Severity | Fixed in |
| --- | --- | --- |
| CVE-2026-78662 | high | v0.56.0 |
| CVE-2026-56855 | high | v0.56.0 |

`x/crypto` v0.56.0 raises its own `go` directive to `1.26.0`, so this also moves:

- the module `go` directive: `1.25.0` -> `1.26.0`
- `docker/versions.yaml` `versions.golang`: `1.25.0` -> `1.26.8` (latest 1.26 patch)
- the fallback `ARG GOLANG_VERSION` default in `docker/templates/test.dockerfile`, kept in sync with `versions.yaml`

`docker/versions.yaml` is the single source of truth for the toolchain used by both the generated Dockerfiles and the `Set up Go` step in `.github/workflows/build.yml`, so it has to move together with the `go` directive — otherwise CI would rely on implicit toolchain download.

`x/crypto` v0.57.0 exists but was published less than a week ago, so v0.56.0 (the version named in the advisories) was chosen instead.

#### Test plan

- [x] `go mod tidy -diff` reports no pending changes
- [x] `GOOS=linux GOARCH=amd64 go build cmd/server/main.go` and `cmd/dependencies/init.go` succeed
- [ ] CI build workflow (amd64 + arm64 Docker image builds) passes on Go 1.26.8

Generated with [Devin](https://devin.ai)